### PR TITLE
Subclass the WndProc of the osu window instead of creating a new one.

### DIFF
--- a/Source/GlobalAssemblyInfo.cs
+++ b/Source/GlobalAssemblyInfo.cs
@@ -12,4 +12,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2006 - 2014 the Open Toolkit Library")]
 [assembly: AssemblyTrademark("OpenTK")]
 [assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.2192.0")]
+[assembly: AssemblyFileVersion("1.1.2206.0")]

--- a/Source/OpenTK/NativeWindow.cs
+++ b/Source/OpenTK/NativeWindow.cs
@@ -58,6 +58,12 @@ namespace OpenTK
         /// System.Threading.Thread.CurrentThread.ManagedThreadId of the thread that created this <see cref="OpenTK.NativeWindow"/>.
         /// </summary>
         private int thread_id;
+
+        /// <summary>
+        /// The Osu window handle.
+        /// </summary>
+        public static IntPtr OsuWindowHandle;
+
         #endregion
 
         #region --- Contructors ---


### PR DESCRIPTION
This is a quick-and-dirty fix to our problems with OpenTK input. OpenTK was creating a new input-only window to handle input, but that introduced some problems. The fix is to not create that window, and instead have OpenTK subclass our WndProc, just like we subclass it.

I've simply removed the code that creates the window, and the thread that reads the messages for that window, and instead passed the osu window to OpenTK to use instead.
