### PR TITLE
More reliable window focus logic

### DIFF
--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -227,6 +227,11 @@ namespace OpenTK.Platform.Windows
 
         void setFocus(bool focus)
         {
+            if (focus && !(Functions.GetForegroundWindow() == window?.Handle))
+            {
+                focus = false;
+            }
+
             if (focus == focused) return;
 
             focused = focus;
@@ -262,7 +267,7 @@ namespace OpenTK.Platform.Windows
             // This is a work-around for the window not having a correct value for focused if the window is
             // denied focus during startup procedures. On looking into all window events during startup,
             // it looks like windows is incorrectly sending ACTIVATE / ACTIVATEAPP WindowProcedures. 
-            setFocus(Functions.GetForegroundWindow() == window?.Handle);
+            // setFocus(Functions.GetForegroundWindow() == window?.Handle);
 
             unsafe
             {
@@ -632,12 +637,7 @@ namespace OpenTK.Platform.Windows
                 }
             }
         }
-
-        void HandleKillFocus(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)
-        {
-            setFocus(false);
-        }
-
+        
         void HandleCreate(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)
         {
             CreateStruct cs = (CreateStruct)Marshal.PtrToStructure(lParam, typeof(CreateStruct));
@@ -796,10 +796,6 @@ namespace OpenTK.Platform.Windows
 
                 case WindowMessage.SYSCHAR:
                     return IntPtr.Zero;
-
-                case WindowMessage.KILLFOCUS:
-                    HandleKillFocus(handle, message, wParam, lParam);
-                    break;
 
                 #endregion
 


### PR DESCRIPTION
Related to ppy/osu-framework#671.

When the game is started and the main window loses focus before being fully initialized, it seems like Windows doesn't always send a WM_ACTIVATE message for de-activation.
So with this new hack, the setFocus method - after receiving a WM_ACTIVATE **activation** message - checks whether the game window actually still is the foreground window.