### PR TITLE
Don't allow bounds to be set when window not present

### DIFF
--- a/src/OpenTK/Platform/X11/X11GLNative.cs
+++ b/src/OpenTK/Platform/X11/X11GLNative.cs
@@ -1251,6 +1251,12 @@ namespace OpenTK.Platform.X11
                         Functions.XResizeWindow(window.Display, window.Handle,
                             width, height);
                     }
+                    else
+                    {
+                        // Setting bounds before the window appears causes the program to hang indefinitely
+                        // at the subsequent call to ProcessEvents(), therefore return here.
+                        return;
+                    }
                 }
 
                 _waitForEvent = XEventName.ConfigureNotify;


### PR DESCRIPTION
Fixes issue: https://github.com/ppy/osu/issues/1834

When launching osu! from command line on Linux, window bounds are set before the window is present.
This causes a subsequent call to `ProcessEvents()` which will hang indefinitely as there is no window for events to be processed from.

Credit to https://github.com/Frassle for the fix.
