### PR TITLE
Expose precise scrolling capability (macOS only) and fix cursor hiding

### DIFF
--- a/src/OpenTK/Input/MouseState.cs
+++ b/src/OpenTK/Input/MouseState.cs
@@ -40,6 +40,8 @@ namespace OpenTK.Input
 
         public RawMouseFlags RawFlags { get; internal set; }
 
+        public bool HasPreciseScroll { get; internal set; }
+
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating whether the specified
         /// <see cref="OpenTK.Input.MouseButton"/> is pressed.

--- a/src/OpenTK/Input/MouseState.cs
+++ b/src/OpenTK/Input/MouseState.cs
@@ -38,9 +38,7 @@ namespace OpenTK.Input
         private MouseScroll scroll;
         private ushort buttons;
 
-        public RawMouseFlags RawFlags { get; internal set; }
-
-        public bool HasPreciseScroll { get; internal set; }
+        public MouseStateFlags Flags { get; internal set; }
 
         /// <summary>
         /// Gets a <see cref="System.Boolean"/> indicating whether the specified
@@ -345,8 +343,33 @@ namespace OpenTK.Input
                 buttons == other.buttons &&
                 X == other.X &&
                 Y == other.Y &&
-                RawFlags == other.RawFlags &&
+                Flags == other.Flags &&
                 Scroll == other.Scroll;
         }
+    }
+
+    [Flags]
+    public enum MouseStateFlags : ushort
+    {
+        /// <summary>
+        /// LastX/Y indicate relative motion.
+        /// </summary>
+        MoveRelative = 0x00,
+        /// <summary>
+        /// LastX/Y indicate absolute motion.
+        /// </summary>
+        MoveAbsolute = 0x01,
+        /// <summary>
+        /// The coordinates are mapped to the virtual desktop.
+        /// </summary>
+        VirtualDesktop = 0x02,
+        /// <summary>
+        /// Requery for mouse attributes.
+        /// </summary>
+        AttributesChanged = 0x04,
+        /// <summary>
+        /// Whether scrolling with this mouse has precise values.
+        /// </summary>
+        HasPreciseScroll = 0x08,
     }
 }

--- a/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
+++ b/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
@@ -316,7 +316,7 @@ namespace OpenTK.Platform.Linux
             {
                 float dx = mouse.Scroll.X - previous_mouse.Scroll.X;
                 float dy = mouse.Scroll.Y - previous_mouse.Scroll.Y;
-                OnMouseWheel(dx, dy);
+                OnMouseWheel(dx, dy, false);
             }
 
             // Handle mouse focus

--- a/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
@@ -158,35 +158,8 @@ namespace OpenTK.Platform.MacOS
             #endif
         }
 
-        // Not the _stret version, perhaps because a NSPoint fits in one register?
-        // thefiddler: gcc is indeed using objc_msgSend for NSPoint on i386
         [DllImport (LibObjC, EntryPoint="objc_msgSend")]
-        public extern static NSPointF SendPointF(IntPtr receiver, IntPtr selector);
-        [DllImport (LibObjC, EntryPoint="objc_msgSend")]
-        public extern static NSPointD SendPointD(IntPtr receiver, IntPtr selector);
-
-        public static NSPoint SendPoint(IntPtr receiver, IntPtr selector)
-        {
-            NSPoint r = new NSPoint();
-
-            unsafe
-            {
-                if (IntPtr.Size == 4)
-                {
-                    NSPointF pf = SendPointF(receiver, selector);
-                    r.X.Value = *(IntPtr *)&pf.X;
-                    r.Y.Value = *(IntPtr *)&pf.Y;
-                }
-                else
-                {
-                    NSPointD pd = SendPointD(receiver, selector);
-                    r.X.Value = *(IntPtr *)&pd.X;
-                    r.Y.Value = *(IntPtr *)&pd.Y;
-                }
-            }
-
-            return r;
-        }
+        public extern static NSPoint SendPoint(IntPtr receiver, IntPtr selector);
 
         [DllImport (LibObjC, EntryPoint="objc_msgSend_stret")]
         private extern static void SendRect(out NSRect retval, IntPtr receiver, IntPtr selector);

--- a/src/OpenTK/Platform/MacOS/Cocoa/NSFloat.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/NSFloat.cs
@@ -39,79 +39,25 @@ namespace OpenTK.Platform.MacOS
     // However, NSFloat is used internally in places where this precision loss does not matter.
     internal struct NSFloat
     {
-        private IntPtr _value;
-
-        public IntPtr Value
-        {
-            get { return _value; }
-            set { _value = value; }
-        }
+        private double _value;
 
         public static implicit operator NSFloat(float v)
         {
             NSFloat f = new NSFloat();
-            unsafe
-            {
-                if (IntPtr.Size == 4)
-                {
-                    f.Value = *(IntPtr*)&v;
-                }
-                else
-                {
-                    double d = v;
-                    f.Value = *(IntPtr*)&d;
-                }
-            }
+            f._value = v;
             return f;
         }
 
         public static implicit operator NSFloat(double v)
         {
             NSFloat f = new NSFloat();
-            unsafe
-            {
-                if (IntPtr.Size == 4)
-                {
-                    float fv = (float)v;
-                    f.Value = *(IntPtr*)&fv;
-                }
-                else
-                {
-                    f.Value = *(IntPtr*)&v;
-                }
-            }
+            f._value = v;
             return f;
         }
 
-        public static implicit operator float(NSFloat f)
-        {
-            unsafe
-            {
-                if (IntPtr.Size == 4)
-                {
-                    return *(float*)&f._value;
-                }
-                else
-                {
-                    return (float)*(double*)&f._value;
-                }
-            }
-        }
+        public static implicit operator float(NSFloat f) => (float)f._value;
 
-        public static implicit operator double(NSFloat f)
-        {
-            unsafe
-            {
-                if (IntPtr.Size == 4)
-                {
-                    return (double)*(float*)&f._value;
-                }
-                else
-                {
-                    return *(double*)&f._value;
-                }
-            }
-        }
+        public static implicit operator double(NSFloat f) => f._value;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -119,6 +65,12 @@ namespace OpenTK.Platform.MacOS
     {
         public NSFloat X;
         public NSFloat Y;
+
+        public NSPoint(NSFloat x, NSFloat y)
+        {
+            X = x;
+            Y = y;
+        }
 
         public static implicit operator NSPoint(PointF p)
         {
@@ -140,6 +92,12 @@ namespace OpenTK.Platform.MacOS
     {
         public NSFloat Width;
         public NSFloat Height;
+
+        public NSSize(NSFloat width, NSFloat height)
+        {
+            Width = width;
+            Height = height;
+        }
 
         public static implicit operator NSSize(SizeF s)
         {
@@ -180,22 +138,5 @@ namespace OpenTK.Platform.MacOS
         {
             return new RectangleF(s.Location, s.Size);
         }
-    }
-
-    // Using IntPtr in NSFloat cause that if imported function
-    // return struct that consist of them you will get wrong data
-    // This types are used for such function.
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct NSPointF
-    {
-        public float X;
-        public float Y;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct NSPointD
-    {
-        public double X;
-        public double Y;
     }
 }

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -762,7 +762,8 @@ namespace OpenTK.Platform.MacOS
                     case NSEventType.ScrollWheel:
                         {
                             float dx, dy;
-                            if (Cocoa.SendBool(e, selHasPreciseScrollingDeltas))
+                            bool isPrecise = Cocoa.SendBool(e, selHasPreciseScrollingDeltas);
+                            if (isPrecise)
                             {
                                 dx = Cocoa.SendFloat(e, selScrollingDeltaX) * MacOSFactory.ScrollFactor;
                                 dy = Cocoa.SendFloat(e, selScrollingDeltaY) * MacOSFactory.ScrollFactor;
@@ -779,7 +780,7 @@ namespace OpenTK.Platform.MacOS
                                 // Note: OpenTK follows the win32 convention, where
                                 // (+h, +v) = (right, up). MacOS reports (+h, +v) = (left, up)
                                 // so we need to flip the horizontal scroll direction.
-                                OnMouseWheel(-dx, dy);
+                                OnMouseWheel(-dx, dy, isPrecise);
                             }
                         }
                         break;
@@ -1172,6 +1173,7 @@ namespace OpenTK.Platform.MacOS
                     NSBitmapFormat.AlphaFirst,
                     4 * cursor.Width,
                     32);
+
             if (imgdata == IntPtr.Zero)
             {
                 Debug.Print("Failed to create NSBitmapImageRep with size ({0},{1]})",

--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -1011,25 +1011,7 @@ namespace OpenTK.Platform.MacOS
         void IMouseDriver2.SetPosition(double x, double y)
         {
             CG.SetLocalEventsSuppressionInterval(0.0);
-
-            NSPoint p = new NSPoint();
-            unsafe
-            {
-                if (IntPtr.Size == 8)
-                {
-                    p.X.Value = *(IntPtr *)&x;
-                    p.Y.Value = *(IntPtr *)&y;
-                }
-                else
-                {
-                    float f1 = (float)x;
-                    float f2 = (float)y;
-                    p.X.Value = *(IntPtr *)&f1;
-                    p.Y.Value = *(IntPtr *)&f2;
-                }
-            }
-
-            CG.DisplayMoveCursorToPoint(CFStringRef.Zero, p);
+            CG.DisplayMoveCursorToPoint(CFStringRef.Zero, new NSPoint(x, y));
         }
 
         KeyboardState IKeyboardDriver2.GetState()

--- a/src/OpenTK/Platform/MacOS/Quartz/DisplayServices.cs
+++ b/src/OpenTK/Platform/MacOS/Quartz/DisplayServices.cs
@@ -130,30 +130,6 @@ namespace OpenTK.Platform.MacOS
         internal static extern CGError SetLocalEventsSuppressionInterval(double seconds);
 
         [DllImport(lib, EntryPoint="CGDisplayMoveCursorToPoint")]
-        internal static extern CGError DisplayMoveCursorToPointNative64(CGDirectDisplayID display, NSPointD point);
-
-        [DllImport(lib, EntryPoint="CGDisplayMoveCursorToPoint")]
-        internal static extern CGError DisplayMoveCursorToPointNative32(CGDirectDisplayID display, NSPointF point);
-
-        internal static CGError DisplayMoveCursorToPoint(CGDirectDisplayID display, NSPoint point)
-        {
-            unsafe
-            {
-                if (IntPtr.Size == 8)
-                {
-                    NSPointD p = new NSPointD();
-                    p.X = *(double *)&point.X;
-                    p.Y = *(double *)&point.Y;
-                    return DisplayMoveCursorToPointNative64(display, p);
-                }
-                else
-                {
-                    NSPointF p = new NSPointF();
-                    p.X = *(float *)&point.X;
-                    p.Y = *(float *)&point.Y;
-                    return DisplayMoveCursorToPointNative32(display, p);
-                }
-            }
-        }
+        internal static extern CGError DisplayMoveCursorToPoint(CGDirectDisplayID display, NSPoint point);
     }
 }

--- a/src/OpenTK/Platform/MacOS/Quartz/EventServices.cs
+++ b/src/OpenTK/Platform/MacOS/Quartz/EventServices.cs
@@ -64,32 +64,7 @@ namespace OpenTK.Platform.MacOS
             CGEventField field);
 
         [DllImport(lib, EntryPoint = "CGEventGetLocation")]
-        internal static extern NSPointF EventGetLocationF(CGEventRef @event);
-        [DllImport(lib, EntryPoint = "CGEventGetLocation")]
-        internal static extern NSPointD EventGetLocationD(CGEventRef @event);
-
-        internal static NSPoint EventGetLocation(CGEventRef @event)
-        {
-            NSPoint r = new NSPoint();
-
-            unsafe {
-                if (IntPtr.Size == 4)
-                {
-                    NSPointF pf = EventGetLocationF(@event);
-                    r.X.Value = *(IntPtr *)&pf.X;
-                    r.Y.Value = *(IntPtr *)&pf.Y;
-                }
-                else
-                {
-                    NSPointD pd = EventGetLocationD(@event);
-                    r.X.Value = *(IntPtr *)&pd.X;
-                    r.Y.Value = *(IntPtr *)&pd.Y;
-                }
-            }
-
-            return r;
-        }
-
+        internal static extern NSPoint EventGetLocation(CGEventRef @event);
     }
 
     internal enum CGEventTapLocation

--- a/src/OpenTK/Platform/NativeWindowBase.cs
+++ b/src/OpenTK/Platform/NativeWindowBase.cs
@@ -275,7 +275,11 @@ namespace OpenTK.Platform
         protected void OnMouseWheel(float dx, float dy, bool isPrecise)
         {
             MouseState.SetScrollRelative(dx, dy);
-            MouseState.HasPreciseScroll = isPrecise;
+
+            if (isPrecise)
+                MouseState.Flags |= MouseStateFlags.HasPreciseScroll;
+            else
+                MouseState.Flags &= ~MouseStateFlags.HasPreciseScroll;
 
             var e = MouseWheelArgs;
             e.Mouse = MouseState;

--- a/src/OpenTK/Platform/NativeWindowBase.cs
+++ b/src/OpenTK/Platform/NativeWindowBase.cs
@@ -272,9 +272,10 @@ namespace OpenTK.Platform
             MouseMove(this, e);
         }
 
-        protected void OnMouseWheel(float dx, float dy)
+        protected void OnMouseWheel(float dx, float dy, bool isPrecise)
         {
             MouseState.SetScrollRelative(dx, dy);
+            MouseState.HasPreciseScroll = isPrecise;
 
             var e = MouseWheelArgs;
             e.Mouse = MouseState;

--- a/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -300,7 +300,7 @@ namespace OpenTK.Platform.SDL2
 
         private static void ProcessMouseWheelEvent(Sdl2NativeWindow window, MouseWheelEvent ev)
         {
-            window.OnMouseWheel(ev.X, ev.Y);
+            window.OnMouseWheel(ev.X, ev.Y, false);
         }
 
         private static unsafe void ProcessDropEvent(Sdl2NativeWindow window, DropEvent ev)

--- a/src/OpenTK/Platform/Windows/WinGLNative.cs
+++ b/src/OpenTK/Platform/Windows/WinGLNative.cs
@@ -538,14 +538,14 @@ namespace OpenTK.Platform.Windows
         {
             // This is due to inconsistent behavior of the WParam value on 64bit arch, whese
             // wparam = 0xffffffffff880000 or wparam = 0x00000000ff100000
-            OnMouseWheel(0, ((long)wParam << 32 >> 48) / 120.0f);
+            OnMouseWheel(0, ((long)wParam << 32 >> 48) / 120.0f, false);
         }
 
         private void HandleMouseHWheel(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)
         {
             // This is due to inconsistent behavior of the WParam value on 64bit arch, whese
             // wparam = 0xffffffffff880000 or wparam = 0x00000000ff100000
-            OnMouseWheel(((long)wParam << 32 >> 48) / 120.0f, 0);
+            OnMouseWheel(((long)wParam << 32 >> 48) / 120.0f, 0, false);
         }
 
         private void HandleLButtonDown(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam)

--- a/src/OpenTK/Platform/Windows/WinRawMouse.cs
+++ b/src/OpenTK/Platform/Windows/WinRawMouse.cs
@@ -239,7 +239,7 @@ namespace OpenTK.Platform.Windows
                     mouse.SetScrollRelative((short)raw.ButtonData / 120.0f, 0);
                 }
 
-                mouse.RawFlags = raw.Flags;
+                mouse.Flags = (MouseStateFlags)raw.Flags;
 
                 if ((raw.Flags & RawMouseFlags.MOUSE_MOVE_ABSOLUTE) != 0)
                 {

--- a/src/OpenTK/Platform/X11/X11GLNative.cs
+++ b/src/OpenTK/Platform/X11/X11GLNative.cs
@@ -1093,7 +1093,7 @@ namespace OpenTK.Platform.X11
                             {
                                 // High resolution scroll events not supported
                                 // fallback to the old Button4-7 scroll buttons
-                                OnMouseWheel(dx, dy);
+                                OnMouseWheel(dx, dy, false);
                             }
                         }
                         break;


### PR DESCRIPTION
In the future, precise scrolling capabilities could also get introduced to Windows. IIRC the surface (pro and book) both have precisely scrolling trackpads, for instance.

This PR also fixes cursor hiding along the way. (closes https://github.com/ppy/osu-framework/issues/1177)