### PR TITLE
Fix broken hidden cursor under release builds on macOS

### DIFF
--- a/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/Cocoa.cs
@@ -82,7 +82,7 @@ namespace OpenTK.Platform.MacOS
         public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, NSRect rectangle1, int int1, IntPtr intPtr1, IntPtr intPtr2);
 
         [DllImport(LibObjC, EntryPoint="objc_msgSend")]
-        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr p1, int p2, int p3, int p4, int p5, int p6, int p7, IntPtr p8, NSBitmapFormat p9, int p10, int p11);
+        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr p1, int p2, int p3, int p4, int p5, bool p6, bool p7, IntPtr p8, NSBitmapFormat p9, int p10, int p11);
 
         [DllImport(LibObjC, EntryPoint="objc_msgSend")]
         public extern static bool SendBool(IntPtr receiver, IntPtr selector);

--- a/src/OpenTK/Platform/MacOS/Cocoa/NSBitmapFormat.cs
+++ b/src/OpenTK/Platform/MacOS/Cocoa/NSBitmapFormat.cs
@@ -30,7 +30,7 @@ using System;
 namespace OpenTK.Platform.MacOS
 {
     [Flags]
-    internal enum NSBitmapFormat
+    internal enum NSBitmapFormat : uint
     {
         AlphaFirst = 1 << 0,
         AlphaNonpremultiplied = 1 << 1,

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -1177,7 +1177,7 @@ namespace OpenTK.Platform.MacOS
 
             if (imgdata == IntPtr.Zero)
             {
-                Debug.Print("Failed to create NSBitmapImageRep with size ({0},{1]})",
+                Debug.Print("Failed to create NSBitmapImageRep with size ({0},{1})",
                     cursor.Width, cursor.Height);
                 return IntPtr.Zero;
             }

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -120,7 +120,7 @@ namespace OpenTK.Platform.MacOS
         private static readonly IntPtr NSCursor;
         private static readonly IntPtr NSImage;
         private static readonly IntPtr NSBitmapImageRep;
-        private static readonly IntPtr NSDeviceRGBColorSpace = Cocoa.ToNSString("NSDeviceRGBColorSpace");
+        private static readonly IntPtr NSDeviceRGBColorSpace;
         private static readonly IntPtr NSFilenamesPboardType;
 
         static CocoaNativeWindow()
@@ -132,6 +132,7 @@ namespace OpenTK.Platform.MacOS
             NSImage = Class.Get("NSImage");
             NSBitmapImageRep = Class.Get("NSBitmapImageRep");
             NSFilenamesPboardType = Cocoa.GetStringConstant(Cocoa.AppKitLibrary, "NSFilenamesPboardType");
+            NSDeviceRGBColorSpace = Cocoa.ToNSString("NSDeviceRGBColorSpace");
         }
 
         private CocoaWindowInfo windowInfo;
@@ -1167,8 +1168,8 @@ namespace OpenTK.Platform.MacOS
                     cursor.Height,
                     8,
                     4,
-                    1,
-                    0,
+                    true,
+                    false,
                     NSDeviceRGBColorSpace,
                     NSBitmapFormat.AlphaFirst,
                     4 * cursor.Width,


### PR DESCRIPTION
What the title says. TL;DR: It is important to marshal `bool` as `bool` and not as `int`. Still need to investigate _why_ exactly, but this got rid of _all_ strange and spooky behaviour I was seeing. The other changes in this PR are not necessary for the code to work, but I'm leaving them in to make things more sane.