### PR TITLE
Fix rewrite targets

### DIFF
--- a/src/OpenTK/OpenTK.NS20.csproj
+++ b/src/OpenTK/OpenTK.NS20.csproj
@@ -702,9 +702,9 @@
     <Compile Include="Platform\MacOS\CoreVideo.cs" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="$(MSBuildThisFileDirectory)..\Generator.Rewrite\bin\Debug\Rewrite.exe $(OutputPath)OpenTK.dll $(MSBuildThisFileDirectory)..\..\OpenTK.snk -debug -netstandard" Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Debug'" />
-    <Exec Command="$(MSBuildThisFileDirectory)..\Generator.Rewrite\bin\Release\Rewrite.exe $(OutputPath)OpenTK.dll $(MSBuildThisFileDirectory)..\..\OpenTK.snk -netstandard" Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Release'" />
-    <Exec Command="mono $(MSBuildThisFileDirectory)../Generator.Rewrite/bin/Debug/Rewrite.exe -a $(OutputPath)OpenTK.dll -debug --netstandard" Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Debug'" />
+    <Exec Command="$(MSBuildThisFileDirectory)..\Generator.Rewrite\bin\Debug\Rewrite.exe -a $(OutputPath)OpenTK.dll -k $(MSBuildThisFileDirectory)..\..\OpenTK.snk --debug --netstandard" Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Debug'" />
+    <Exec Command="$(MSBuildThisFileDirectory)..\Generator.Rewrite\bin\Release\Rewrite.exe -a $(OutputPath)OpenTK.dll -k $(MSBuildThisFileDirectory)..\..\OpenTK.snk --netstandard" Condition="$(OS) == 'Windows_NT' and $(Configuration) == 'Release'" />
+    <Exec Command="mono $(MSBuildThisFileDirectory)../Generator.Rewrite/bin/Debug/Rewrite.exe -a $(OutputPath)OpenTK.dll --debug --netstandard" Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Debug'" />
     <Exec Command="mono $(MSBuildThisFileDirectory)../Generator.Rewrite/bin/Release/Rewrite.exe -a $(OutputPath)OpenTK.dll --netstandard" Condition="$(OS) != 'Windows_NT' and $(Configuration) == 'Release'" />
   </Target>
 </Project>


### PR DESCRIPTION
This currently never works on windows, and I'd suspect that only release builds on mono currently work correctly due to these being wrong.

EDIT: For reference:
```
.\Rewrite.exe --help
Generator 3.0.0.0
Copyright (c) 2006 - 2016 Stefanos Apostolopoulos <stapostol@gmail.com> for the Open Toolkit library.

  -a, --assembly       Required. The path to the target assembly that should be rewritten.

  -k, --signing-key    The path to the strong name key which should be used to sign or resign the assembly.

  -d, --debug          (Default: false) Enable calls to GL.GetError(), wrapped around each native call.

  --dllimport          (Default: false) Force native calls to use DllImport instead of GetProcAddress.

  --netstandard        (Default: false) Rewrite with compatibility with .NET Standard.

  --help               Display this help screen.

  --version            Display version information.
```