### PR TITLE
Implement DisplayDevice.FromRectangle(Rectangle)

### DIFF
--- a/src/OpenTK/DisplayDevice.cs
+++ b/src/OpenTK/DisplayDevice.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace OpenTK
 {
@@ -284,6 +285,32 @@ namespace OpenTK
                 }
             }
             return null;
+        }
+
+        /// <summary> 
+        /// Gets the <see cref="DisplayDevice"/> that has the largest intersecting area with a specific <see cref="Rectangle"/> structure. 
+        /// </summary> 
+        /// <param name="bounds">The <see cref="Rectangle"/> (usually window bounds) for which we want to find the <see cref="DisplayDevice"/>.</param> 
+        /// <returns>A <see cref="DisplayDevice"/> that contains the biggest part of the specified <see cref="Rectangle"/> out of all available devices.</returns> 
+        public static DisplayDevice FromRectangle(Rectangle bounds)
+        {
+            DisplayDevice result = null;
+            int biggestArea = 0;
+            foreach (var device in implementation.AvailableDevices.Where(d => d.Bounds.IntersectsWith(bounds)))
+            {
+                Rectangle windowPortionOnScreen = device.Bounds;
+                windowPortionOnScreen.Intersect(bounds);
+
+                int windowPortionArea = windowPortionOnScreen.Width * windowPortionOnScreen.Height;
+
+                if (windowPortionArea > biggestArea)
+                {
+                    biggestArea = windowPortionArea;
+                    result = device;
+                }
+            }
+
+            return result;
         }
 
         private DisplayResolution FindResolution(int width, int height, int bitsPerPixel, float refreshRate)

--- a/src/OpenTK/Platform/DisplayDeviceBase.cs
+++ b/src/OpenTK/Platform/DisplayDeviceBase.cs
@@ -29,7 +29,7 @@ namespace OpenTK.Platform
 {
     internal abstract class DisplayDeviceBase : IDisplayDeviceDriver
     {
-        protected readonly List<DisplayDevice> AvailableDevices = new List<DisplayDevice>();
+        public List<DisplayDevice> AvailableDevices { get; } = new List<DisplayDevice>();
         protected DisplayDevice Primary;
 
         public abstract bool TryChangeResolution(DisplayDevice device, DisplayResolution resolution);

--- a/src/OpenTK/Platform/IDisplayDeviceDriver.cs
+++ b/src/OpenTK/Platform/IDisplayDeviceDriver.cs
@@ -23,6 +23,8 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Collections.Generic;
+
 namespace OpenTK.Platform
 {
     internal interface IDisplayDeviceDriver
@@ -30,5 +32,6 @@ namespace OpenTK.Platform
         bool TryChangeResolution(DisplayDevice device, DisplayResolution resolution);
         bool TryRestoreResolution(DisplayDevice device);
         DisplayDevice GetDisplay(DisplayIndex displayIndex);
+        List<DisplayDevice> AvailableDevices { get; }
     }
 }


### PR DESCRIPTION
This method finds the monitor which contains the biggest part of a given rectangle (usage: biggest part of a window, `DisplayDevice.FromRectangle(window.Bounds)`). This is a prerequisite for multi-monitor handling in fullscreen logic.

I prefer this approach to just using the center point of the window to find a monitor via  `FromPoint` (FYI, Windows also uses this approach ([see here](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-monitorfromwindow)) in their API)