### PR TITLE
Add an API for getting all raw device states at once

### DIFF
--- a/src/OpenTK/Input/IJoystickDriver2.cs
+++ b/src/OpenTK/Input/IJoystickDriver2.cs
@@ -32,6 +32,7 @@ namespace OpenTK.Input
     internal interface IJoystickDriver2
     {
         JoystickState GetState(int index);
+        JoystickState[] GetStates();
         JoystickCapabilities GetCapabilities(int index);
         Guid GetGuid(int index);
     }

--- a/src/OpenTK/Input/IKeyboardDriver2.cs
+++ b/src/OpenTK/Input/IKeyboardDriver2.cs
@@ -16,6 +16,12 @@
         KeyboardState GetState(int index);
 
         /// <summary>
+        /// Retrives <see cref="OpenTK.Input.KeyboardState"/> for all keyboard devices.
+        /// </summary>
+        /// <returns>An array of <see cref="OpenTK.Input.KeyboardState"/> representing the state for the keyboard devices.</returns>
+        KeyboardState[] GetStates();
+
+        /// <summary>
         /// Retrieves the device name for the keyboard device.
         /// </summary>
         /// <param name="index">The index of the keyboard device.</param>

--- a/src/OpenTK/Input/IMouseDriver2.cs
+++ b/src/OpenTK/Input/IMouseDriver2.cs
@@ -29,6 +29,7 @@ namespace OpenTK.Input
     {
         MouseState GetState();
         MouseState GetState(int index);
+        MouseState[] GetStates();
         void SetPosition(double x, double y);
         MouseState GetCursorState();
     }

--- a/src/OpenTK/Input/Joystick.cs
+++ b/src/OpenTK/Input/Joystick.cs
@@ -76,6 +76,15 @@ namespace OpenTK.Input
         }
 
         /// <summary>
+        /// Retrives <see cref="OpenTK.Input.JoystickState"/> for all joystick devices.
+        /// </summary>
+        /// <returns>An array of <see cref="OpenTK.Input.JoystickState"/> representing the state for the joystick devices.</returns>
+        public static JoystickState[] GetStates()
+        {
+            return implementation.GetStates();
+        }
+
+        /// <summary>
         /// Retrieves the ID of the device connected
         /// at the specified index.
         /// </summary>

--- a/src/OpenTK/Input/Keyboard.cs
+++ b/src/OpenTK/Input/Keyboard.cs
@@ -67,6 +67,18 @@ namespace OpenTK.Input
             }
         }
 
+        /// <summary>
+        /// Retrives <see cref="OpenTK.Input.KeyboardState"/> for all keyboard devices.
+        /// </summary>
+        /// <returns>An array of <see cref="OpenTK.Input.KeyboardState"/> representing the state for the keyboard devices.</returns>
+        public static KeyboardState[] GetStates()
+        {
+            lock (SyncRoot)
+            {
+                return driver.GetStates();
+            }
+        }
+
 #if false
         // Disabled until a correct, cross-platform API can be defined.
 

--- a/src/OpenTK/Input/Mouse.cs
+++ b/src/OpenTK/Input/Mouse.cs
@@ -80,6 +80,18 @@ namespace OpenTK.Input
         }
 
         /// <summary>
+        /// Retrives <see cref="OpenTK.Input.MouseState"/> for all mouse device.
+        /// </summary>
+        /// <returns>An array of <see cref="OpenTK.Input.MouseState"/> representing the state for the mouse devices.</returns>
+        public static MouseState[] GetStates()
+        {
+            lock (SyncRoot)
+            {
+                return driver.GetStates();
+            }
+        }
+
+        /// <summary>
         /// Retreves the <see cref="OpenTK.Input.MouseState"/> for the mouse cursor.
         /// The X and Y coordinates are defined in absolute desktop points, with the origin
         /// placed at the top-left corner of <see cref="OpenTK.DisplayDevice.Default"/>.

--- a/src/OpenTK/Platform/Linux/LinuxInput.cs
+++ b/src/OpenTK/Platform/Linux/LinuxInput.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Diagnostics;
 using System.Drawing;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using OpenTK.Input;
@@ -641,6 +642,14 @@ namespace OpenTK.Platform.Linux
                 {
                     return new MouseState();
                 }
+            }
+        }
+
+        MouseState[] IMouseDriver2.GetStates()
+        {
+            lock (Sync)
+            {
+                return Mice.Select(m => m.State).ToArray();
             }
         }
 

--- a/src/OpenTK/Platform/Linux/LinuxInput.cs
+++ b/src/OpenTK/Platform/Linux/LinuxInput.cs
@@ -600,6 +600,14 @@ namespace OpenTK.Platform.Linux
             }
         }
 
+        KeyboardState[] IKeyboardDriver2.GetStates()
+        {
+            lock (Sync)
+            {
+                return Keyboards.Select(device => device.State).ToArray();
+            }
+        }
+
         string IKeyboardDriver2.GetDeviceName(int index)
         {
             lock (Sync)

--- a/src/OpenTK/Platform/Linux/LinuxJoystick.cs
+++ b/src/OpenTK/Platform/Linux/LinuxJoystick.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using OpenTK.Input;
 
 namespace OpenTK.Platform.Linux
@@ -487,6 +488,11 @@ namespace OpenTK.Platform.Linux
                 return js.State;
             }
             return new JoystickState();
+        }
+
+        JoystickState[] IJoystickDriver2.GetStates()
+        {
+            return Enumerable.Range(0, Sticks.Count).Select(index => ((IJoystickDriver2)this).GetState(index)).ToArray();
         }
 
         JoystickCapabilities IJoystickDriver2.GetCapabilities(int index)

--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -1070,6 +1070,11 @@ namespace OpenTK.Platform.MacOS
             return new JoystickState();
         }
 
+        JoystickState[] IJoystickDriver2.GetStates()
+        {
+            return JoystickDevices.Select(device => device.State).ToArray();
+        }
+
         JoystickCapabilities IJoystickDriver2.GetCapabilities(int index)
         {
             JoystickData joystick = GetJoystick(index);

--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -1042,6 +1042,11 @@ namespace OpenTK.Platform.MacOS
             return new KeyboardState();
         }
 
+        public KeyboardState[] GetStates()
+        {
+            return KeyboardDevices.Select(device => device.State).ToArray();
+        }
+
         string IKeyboardDriver2.GetDeviceName(int index)
         {
             KeyboardData keyboard;

--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -1009,7 +1009,6 @@ namespace OpenTK.Platform.MacOS
             return MouseDevices.Select(d => d.State).ToArray();
         }
 
-
         MouseState IMouseDriver2.GetCursorState()
         {
             return CursorState;

--- a/src/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/src/OpenTK/Platform/MacOS/HIDInput.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using OpenTK.Input;
 using OpenTK.Platform.Common;
@@ -1002,6 +1003,12 @@ namespace OpenTK.Platform.MacOS
 
             return new MouseState();
         }
+
+        MouseState[] IMouseDriver2.GetStates()
+        {
+            return MouseDevices.Select(d => d.State).ToArray();
+        }
+
 
         MouseState IMouseDriver2.GetCursorState()
         {

--- a/src/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using OpenTK.Input;
 
 namespace OpenTK.Platform.SDL2
@@ -626,6 +627,11 @@ namespace OpenTK.Platform.SDL2
             }
 
             return state;
+        }
+
+        JoystickState[] IJoystickDriver2.GetStates()
+        {
+            return Enumerable.Range(0, joysticks.Count).Select(index => ((IJoystickDriver2)this).GetState(index)).ToArray();
         }
 
         JoystickCapabilities IJoystickDriver2.GetCapabilities(int index)

--- a/src/OpenTK/Platform/SDL2/Sdl2Keyboard.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2Keyboard.cs
@@ -93,6 +93,11 @@ namespace OpenTK.Platform.SDL2
             }
         }
 
+        public KeyboardState[] GetStates()
+        {
+            return new[] {GetState(0)};
+        }
+
         public string GetDeviceName(int index)
         {
             return "SDL2 Default Keyboard";

--- a/src/OpenTK/Platform/SDL2/Sdl2Mouse.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2Mouse.cs
@@ -117,6 +117,11 @@ namespace OpenTK.Platform.SDL2
             }
         }
 
+        public MouseState[] GetStates()
+        {
+            return new[] { GetState(0) };
+        }
+
         public MouseState GetCursorState()
         {
             int x, y;

--- a/src/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using OpenTK.Input;
 using OpenTK.Platform.Common;
@@ -817,6 +818,14 @@ namespace OpenTK.Platform.Windows
                     }
                 }
                 return new JoystickState();
+            }
+        }
+
+        public JoystickState[] GetStates()
+        {
+            lock (UpdateLock)
+            {
+                return Enumerable.Range(0, Devices.Count()).Select(GetState).ToArray();
             }
         }
 

--- a/src/OpenTK/Platform/Windows/WinRawKeyboard.cs
+++ b/src/OpenTK/Platform/Windows/WinRawKeyboard.cs
@@ -290,6 +290,14 @@ namespace OpenTK.Platform.Windows
             }
         }
 
+        public KeyboardState[] GetStates()
+        {
+            lock (UpdateLock)
+            {
+                return keyboards.ToArray();
+            }
+        }
+
         public string GetDeviceName(int index)
         {
             lock (UpdateLock)

--- a/src/OpenTK/Platform/Windows/WinRawMouse.cs
+++ b/src/OpenTK/Platform/Windows/WinRawMouse.cs
@@ -352,6 +352,14 @@ namespace OpenTK.Platform.Windows
             }
         }
 
+        public MouseState[] GetStates()
+        {
+            lock (UpdateLock)
+            {
+                return mice.ToArray();
+            }
+        }
+
         public void SetPosition(double x, double y)
         {
             Functions.SetCursorPos((int)x, (int)y);

--- a/src/OpenTK/Platform/Windows/XInputJoystick.cs
+++ b/src/OpenTK/Platform/Windows/XInputJoystick.cs
@@ -476,6 +476,11 @@ namespace OpenTK.Platform.Windows
             }
         }
 
+        public JoystickState[] GetStates()
+        {
+            throw new NotImplementedException($"Use {nameof(WinRawJoystick)}'s {nameof(GetStates)} instead");
+        }
+
 #if DEBUG
         ~XInputJoystick()
         {

--- a/src/OpenTK/Platform/X11/X11Keyboard.cs
+++ b/src/OpenTK/Platform/X11/X11Keyboard.cs
@@ -90,6 +90,11 @@ namespace OpenTK.Platform.X11
             }
         }
 
+        public KeyboardState[] GetStates()
+        {
+            return new[] {GetState(0)};
+        }
+
         public string GetDeviceName(int index)
         {
             if (index == 0)

--- a/src/OpenTK/Platform/X11/X11Mouse.cs
+++ b/src/OpenTK/Platform/X11/X11Mouse.cs
@@ -82,6 +82,11 @@ namespace OpenTK.Platform.X11
             }
         }
 
+        public MouseState[] GetStates()
+        {
+            return new[] { GetState(0) };
+        }
+
         public MouseState GetCursorState()
         {
             ProcessEvents();

--- a/src/OpenTK/Platform/X11/XI2MouseKeyboard.cs
+++ b/src/OpenTK/Platform/X11/XI2MouseKeyboard.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using OpenTK.Input;
@@ -226,6 +227,14 @@ namespace OpenTK.Platform.X11
                     return devices[index].State;
                 }
                 return new MouseState();
+            }
+        }
+
+        MouseState[] IMouseDriver2.GetStates()
+        {
+            lock (Sync)
+            {
+                return devices.Select(d => d.State).ToArray();
             }
         }
 

--- a/src/OpenTK/Platform/X11/XI2MouseKeyboard.cs
+++ b/src/OpenTK/Platform/X11/XI2MouseKeyboard.cs
@@ -193,6 +193,14 @@ namespace OpenTK.Platform.X11
             }
         }
 
+        public KeyboardState[] GetStates()
+        {
+            lock (Sync)
+            {
+                return keyboards.Select(device => device.State).ToArray();
+            }
+        }
+
         string IKeyboardDriver2.GetDeviceName(int index)
         {
             lock (Sync)


### PR DESCRIPTION
<!--
The current osu-framework logic for getting all states [(code link)](https://github.com/ppy/osu-framework/blob/440a3d3d9e9ebcda4a6f4088820f10edfa94b7c6/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs#L55) is awkward and wrong (ppy/osu#3073).
<s>Keyboard and Joystick API can be changed the same but should I do? Keyboard raw device API is not used in osu-framework currently but joystick raw device API is.</s> -&gt; Added Keyboard and Joystick APIs.
-->
Add an API for getting all raw device states at once.
For Mouse, Keyboard and Joystick.
Only tested on Windows.