### PR TITLE
Remove .dll when importing dlls to make coreclr automatically handle it.

### DIFF
--- a/src/OpenTK.GLControl/Sdl2GLControl.cs
+++ b/src/OpenTK.GLControl/Sdl2GLControl.cs
@@ -58,7 +58,7 @@ namespace OpenTK
 
         private static class NativeMethods
         {
-            [DllImport("SDL2.dll", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("SDL2", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool SDL_HasEvents(int minType, int maxType);
         }
     }

--- a/src/OpenTK/Graphics/ES20/Helper.cs
+++ b/src/OpenTK/Graphics/ES20/Helper.cs
@@ -38,7 +38,7 @@ namespace OpenTK.Graphics.ES20
 #if IPHONE
         private const string Library = "/System/Library/Frameworks/OpenGLES.framework/OpenGLES";
 #else
-        private const string Library = "libGLESv2.dll";
+        private const string Library = "GLESv2";
 #endif
         private static readonly object sync_root = new object();
 

--- a/src/OpenTK/Graphics/ES30/Helper.cs
+++ b/src/OpenTK/Graphics/ES30/Helper.cs
@@ -38,7 +38,7 @@ namespace OpenTK.Graphics.ES30
 #if IPHONE
         private const string Library = "/System/Library/Frameworks/OpenGLES.framework/OpenGLES";
 #else
-        private const string Library = "libGLESv2.dll";
+        private const string Library = "GLESv2";
 #endif
         private static readonly object sync_root = new object();
 

--- a/src/OpenTK/Platform/Egl/Egl.cs
+++ b/src/OpenTK/Platform/Egl/Egl.cs
@@ -209,10 +209,10 @@ namespace OpenTK.Platform.Egl
         // EGL_ANGLE_window_fixed_size
         public const int FIXED_SIZE_ANGLE = 0x3201;
         // EGL_ANGLE_query_surface_pointer
-        [DllImport("libEGL.dll", EntryPoint = "eglQuerySurfacePointerANGLE")]
+        [DllImport("EGL", EntryPoint = "eglQuerySurfacePointerANGLE")]
         public static extern bool QuerySurfacePointerANGLE(EGLDisplay display, EGLSurface surface, int attribute, out IntPtr value);
 
-        [DllImport("libEGL.dll", EntryPoint = "eglGetPlatformDisplayEXT")]
+        [DllImport("EGL", EntryPoint = "eglGetPlatformDisplayEXT")]
         public static extern EGLDisplay GetPlatformDisplay(int platform, EGLNativeDisplayType displayId, int[] attribList);
 
         // EGL_ANGLE_software_display
@@ -243,87 +243,87 @@ namespace OpenTK.Platform.Egl
         // See EGL_ANGLE_surface_d3d_texture_2d_share_handle
         public const int EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE = 0x3200;
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetError")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetError")]
         public static extern ErrorCode GetError();
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetDisplay")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetDisplay")]
         public static extern EGLDisplay GetDisplay(EGLNativeDisplayType display_id);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglInitialize")]
+        [DllImportAttribute("EGL", EntryPoint = "eglInitialize")]
         //[return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool Initialize(EGLDisplay dpy, out int major, out int minor);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglTerminate")]
+        [DllImportAttribute("EGL", EntryPoint = "eglTerminate")]
         //[return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool Terminate(EGLDisplay dpy);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglQueryString")]
+        [DllImportAttribute("EGL", EntryPoint = "eglQueryString")]
         public static extern IntPtr QueryString(EGLDisplay dpy, int name);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetConfigs")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetConfigs")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool GetConfigs(EGLDisplay dpy, EGLConfig[] configs, int config_size, out int num_config);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglChooseConfig")]
+        [DllImportAttribute("EGL", EntryPoint = "eglChooseConfig")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool ChooseConfig(EGLDisplay dpy, int[] attrib_list, [In, Out] EGLConfig[] configs, int config_size, out int num_config);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetConfigAttrib")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetConfigAttrib")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool GetConfigAttrib(EGLDisplay dpy, EGLConfig config, int attribute, out int value);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglCreateWindowSurface")]
+        [DllImportAttribute("EGL", EntryPoint = "eglCreateWindowSurface")]
         public static extern  EGLSurface CreateWindowSurface(EGLDisplay dpy, EGLConfig config, IntPtr win, IntPtr attrib_list);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglCreatePbufferSurface")]
+        [DllImportAttribute("EGL", EntryPoint = "eglCreatePbufferSurface")]
         public static extern EGLSurface CreatePbufferSurface(EGLDisplay dpy, EGLConfig config, int[] attrib_list);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglCreatePixmapSurface")]
+        [DllImportAttribute("EGL", EntryPoint = "eglCreatePixmapSurface")]
         public static extern EGLSurface CreatePixmapSurface(EGLDisplay dpy, EGLConfig config, EGLNativePixmapType pixmap, int[] attrib_list);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglDestroySurface")]
+        [DllImportAttribute("EGL", EntryPoint = "eglDestroySurface")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool DestroySurface(EGLDisplay dpy, EGLSurface surface);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglQuerySurface")]
+        [DllImportAttribute("EGL", EntryPoint = "eglQuerySurface")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool QuerySurface(EGLDisplay dpy, EGLSurface surface, int attribute, out int value);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglBindAPI")]
+        [DllImportAttribute("EGL", EntryPoint = "eglBindAPI")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool BindAPI(RenderApi api);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglQueryAPI")]
+        [DllImportAttribute("EGL", EntryPoint = "eglQueryAPI")]
         public static extern int QueryAPI();
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglWaitClient")]
+        [DllImportAttribute("EGL", EntryPoint = "eglWaitClient")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool WaitClient();
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglReleaseThread")]
+        [DllImportAttribute("EGL", EntryPoint = "eglReleaseThread")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool ReleaseThread();
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglCreatePbufferFromClientBuffer")]
+        [DllImportAttribute("EGL", EntryPoint = "eglCreatePbufferFromClientBuffer")]
         public static extern EGLSurface CreatePbufferFromClientBuffer(EGLDisplay dpy, int buftype, EGLClientBuffer buffer, EGLConfig config, int[] attrib_list);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglSurfaceAttrib")]
+        [DllImportAttribute("EGL", EntryPoint = "eglSurfaceAttrib")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool SurfaceAttrib(EGLDisplay dpy, EGLSurface surface, int attribute, int value);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglBindTexImage")]
+        [DllImportAttribute("EGL", EntryPoint = "eglBindTexImage")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool BindTexImage(EGLDisplay dpy, EGLSurface surface, int buffer);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglReleaseTexImage")]
+        [DllImportAttribute("EGL", EntryPoint = "eglReleaseTexImage")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool ReleaseTexImage(EGLDisplay dpy, EGLSurface surface, int buffer);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglSwapInterval")]
+        [DllImportAttribute("EGL", EntryPoint = "eglSwapInterval")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool SwapInterval(EGLDisplay dpy, int interval);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglCreateContext")]
+        [DllImportAttribute("EGL", EntryPoint = "eglCreateContext")]
         private static extern IntPtr eglCreateContext(EGLDisplay dpy, EGLConfig config, EGLContext share_context, int[] attrib_list);
 
         public static EGLContext CreateContext(EGLDisplay dpy, EGLConfig config, EGLContext share_context, int[] attrib_list)
@@ -336,57 +336,57 @@ namespace OpenTK.Platform.Egl
             return ptr;
         }
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglDestroyContext")]
+        [DllImportAttribute("EGL", EntryPoint = "eglDestroyContext")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool DestroyContext(EGLDisplay dpy, EGLContext ctx);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglMakeCurrent")]
+        [DllImportAttribute("EGL", EntryPoint = "eglMakeCurrent")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool MakeCurrent(EGLDisplay dpy, EGLSurface draw, EGLSurface read, EGLContext ctx);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetCurrentContext")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetCurrentContext")]
         public static extern EGLContext GetCurrentContext();
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetCurrentSurface")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetCurrentSurface")]
         public static extern EGLSurface GetCurrentSurface(int readdraw);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetCurrentDisplay")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetCurrentDisplay")]
         public static extern EGLDisplay GetCurrentDisplay();
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglQueryContext")]
+        [DllImportAttribute("EGL", EntryPoint = "eglQueryContext")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool QueryContext(EGLDisplay dpy, EGLContext ctx, int attribute, out int value);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglWaitGL")]
+        [DllImportAttribute("EGL", EntryPoint = "eglWaitGL")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool WaitGL();
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglWaitNative")]
+        [DllImportAttribute("EGL", EntryPoint = "eglWaitNative")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool WaitNative(int engine);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglSwapBuffers")]
+        [DllImportAttribute("EGL", EntryPoint = "eglSwapBuffers")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool SwapBuffers(EGLDisplay dpy, EGLSurface surface);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglCopyBuffers")]
+        [DllImportAttribute("EGL", EntryPoint = "eglCopyBuffers")]
         [return: MarshalAsAttribute(UnmanagedType.I1)]
         public static extern bool CopyBuffers(EGLDisplay dpy, EGLSurface surface, EGLNativePixmapType target);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetProcAddress")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetProcAddress")]
         public static extern IntPtr GetProcAddress(string funcname);
 
-        [DllImportAttribute("libEGL.dll", EntryPoint = "eglGetProcAddress")]
+        [DllImportAttribute("EGL", EntryPoint = "eglGetProcAddress")]
         public static extern IntPtr GetProcAddress(IntPtr funcname);
 
         // EGL_EXT_platform_base
-        [DllImport("libEGL.dll", EntryPoint = "eglGetPlatformDisplayEXT")]
+        [DllImport("EGL", EntryPoint = "eglGetPlatformDisplayEXT")]
         public static extern EGLDisplay GetPlatformDisplayEXT(int platform, EGLNativeDisplayType native_display, int[] attrib_list);
 
-        [DllImport("libEGL.dll", EntryPoint = "eglCreatePlatformWindowSurfaceEXT")]
+        [DllImport("EGL", EntryPoint = "eglCreatePlatformWindowSurfaceEXT")]
         public static extern EGLSurface CreatePlatformWindowSurfaceEXT(EGLDisplay dpy, EGLConfig config, EGLNativeWindowType native_window, int[] attrib_list);
 
-        [DllImport("libEGL.dll", EntryPoint = "eglCreatePlatformPixmapSurfaceEXT")]
+        [DllImport("EGL", EntryPoint = "eglCreatePlatformPixmapSurfaceEXT")]
         public static extern EGLSurface CreatePlatformPixmapSurfaceEXT(EGLDisplay dpy, EGLConfig config, EGLNativePixmapType native_pixmap, int[] attrib_list);
 
         // Returns true if Egl drivers exist on the system.

--- a/src/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2.cs
@@ -42,7 +42,7 @@ namespace OpenTK.Platform.SDL2
         #elif IPHONE
         const string lib = "__Internal";
         #else
-        private const string lib = "SDL2.dll";
+        private const string lib = "SDL2";
         #endif
 
         public readonly static object Sync = new object();


### PR DESCRIPTION
This fixes SDL and EGL issues on macOS and Linux, if you disable just my code and enable all exceptions, you will see that it complains about not finding libEGL.dll and SDL2.dll at the start. Some libraries like openal, have annoying names like openal32.dll on windows, which would require changing out dllimport to fix.

OpenTK uses dllmap to fix this, but we don't have that under net core.

- Closes https://github.com/ppy/osu/issues/2875
- Probably fixes other issues on macOS and Linux as well
---

Fix refresh rate on macOS and Linux under .NET CORE