### PR TITLE
Fix SDL and X11 Library file names

### DIFF
--- a/src/OpenTK.GLControl/Sdl2GLControl.cs
+++ b/src/OpenTK.GLControl/Sdl2GLControl.cs
@@ -58,7 +58,7 @@ namespace OpenTK
 
         private static class NativeMethods
         {
-            [DllImport("libSDL2-2.so.0", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("libSDL2-2.0.so.0", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool SDL_HasEvents(int minType, int maxType);
         }
     }

--- a/src/OpenTK.GLControl/Sdl2GLControl.cs
+++ b/src/OpenTK.GLControl/Sdl2GLControl.cs
@@ -58,7 +58,7 @@ namespace OpenTK
 
         private static class NativeMethods
         {
-            [DllImport("SDL2", CallingConvention = CallingConvention.Cdecl)]
+            [DllImport("libSDL2-2.so.0", CallingConvention = CallingConvention.Cdecl)]
             public static extern bool SDL_HasEvents(int minType, int maxType);
         }
     }

--- a/src/OpenTK.GLControl/X11GLControl.cs
+++ b/src/OpenTK.GLControl/X11GLControl.cs
@@ -15,10 +15,11 @@ namespace OpenTK
 {
     internal class X11GLControl : IGLControl
     {
-        [DllImport("libX11")]
+        private const string lib = "libX11.so.6";
+        [DllImport(lib)]
         private static extern IntPtr XCreateColormap(IntPtr display, IntPtr window, IntPtr visual, int alloc);
 
-        [DllImport("libX11", EntryPoint = "XGetVisualInfo")]
+        [DllImport(lib, EntryPoint = "XGetVisualInfo")]
         private static extern IntPtr XGetVisualInfoInternal(IntPtr display, IntPtr vinfo_mask, ref XVisualInfo template, out int nitems);
 
         private static IntPtr XGetVisualInfo(IntPtr display, int vinfo_mask, ref XVisualInfo template, out int nitems)
@@ -26,7 +27,7 @@ namespace OpenTK
             return XGetVisualInfoInternal(display, (IntPtr)vinfo_mask, ref template, out nitems);
         }
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         private extern static int XPending(IntPtr diplay);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/OpenTK.GLControl/X11GLControl.cs
+++ b/src/OpenTK.GLControl/X11GLControl.cs
@@ -16,6 +16,7 @@ namespace OpenTK
     internal class X11GLControl : IGLControl
     {
         private const string lib = "libX11.so.6";
+
         [DllImport(lib)]
         private static extern IntPtr XCreateColormap(IntPtr display, IntPtr window, IntPtr visual, int alloc);
 

--- a/src/OpenTK/Platform/Linux/Bindings/Drm.cs
+++ b/src/OpenTK/Platform/Linux/Bindings/Drm.cs
@@ -48,7 +48,7 @@ namespace OpenTK.Platform.Linux
 
     internal class Drm
     {
-        private const string lib = "libdrm";
+        private const string lib = "libdrm.so.2";
 
         [DllImport(lib, EntryPoint = "drmHandleEvent", CallingConvention = CallingConvention.Cdecl)]
         public static extern int HandleEvent(int fd, ref EventContext evctx);

--- a/src/OpenTK/Platform/Linux/Bindings/Gbm.cs
+++ b/src/OpenTK/Platform/Linux/Bindings/Gbm.cs
@@ -39,7 +39,7 @@ namespace OpenTK.Platform.Linux
 
     internal class Gbm
     {
-        private const string lib = "gbm";
+        private const string lib = "libgbm.so.1";
 
         [DllImport(lib, EntryPoint = "gbm_bo_create", CallingConvention = CallingConvention.Cdecl)]
         public static extern BufferObject CreateBuffer(Device gbm, int width, int height, SurfaceFormat format, SurfaceFlags flags);

--- a/src/OpenTK/Platform/Linux/Bindings/Kms.cs
+++ b/src/OpenTK/Platform/Linux/Bindings/Kms.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Platform.Linux
 {
     internal class Kms
     {
-        private const string lib = "libkms";
+        private const string lib = "libkms.so.1";
 
         [DllImport(lib, EntryPoint = "kms_bo_map", CallingConvention = CallingConvention.Cdecl)]
         public static extern int MapBuffer(IntPtr bo, out IntPtr @out);

--- a/src/OpenTK/Platform/Linux/Bindings/LibInput.cs
+++ b/src/OpenTK/Platform/Linux/Bindings/LibInput.cs
@@ -40,7 +40,7 @@ namespace OpenTK.Platform.Linux
 
     internal class LibInput
     {
-        internal const string lib = "libinput";
+        internal const string lib = "libinput.so.10";
 
         [DllImport(lib, EntryPoint = "libinput_udev_create_context", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr CreateContext(InputInterface @interface,

--- a/src/OpenTK/Platform/Linux/Bindings/Terminal.cs
+++ b/src/OpenTK/Platform/Linux/Bindings/Terminal.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Platform.Linux
 {
     internal class Terminal
     {
-        private const string lib = "libc";
+        private const string lib = "libc.so.6";
 
         [DllImport(lib, EntryPoint = "isatty", CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I4)]

--- a/src/OpenTK/Platform/Linux/Bindings/Udev.cs
+++ b/src/OpenTK/Platform/Linux/Bindings/Udev.cs
@@ -32,7 +32,7 @@ namespace OpenTK.Platform.Linux
 {
     internal class Udev
     {
-        private const string lib = "libudev";
+        private const string lib = "libudev.so.1";
 
         [DllImport(lib, EntryPoint = "udev_new", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr New();

--- a/src/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2.cs
@@ -42,7 +42,7 @@ namespace OpenTK.Platform.SDL2
         #elif IPHONE
         const string lib = "__Internal";
         #else
-        private const string lib = "libSDL2-2.so.0";
+        private const string lib = "libSDL2-2.0.so.0";
         #endif
 
         public readonly static object Sync = new object();

--- a/src/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2.cs
@@ -42,7 +42,7 @@ namespace OpenTK.Platform.SDL2
         #elif IPHONE
         const string lib = "__Internal";
         #else
-        private const string lib = "SDL2";
+        private const string lib = "libSDL2-2.so.0";
         #endif
 
         public readonly static object Sync = new object();

--- a/src/OpenTK/Platform/X11/API.cs
+++ b/src/OpenTK/Platform/X11/API.cs
@@ -65,8 +65,8 @@ namespace OpenTK.Platform.X11
 
     internal static class API
     {
-        private const string _dll_name = "libX11";
-        private const string _dll_name_vid = "libXxf86vm";
+        private const string _dll_name = "libX11.so.6";
+        private const string _dll_name_vid = "libXxf86vm.so.1";
 
         private static Window rootWindow;
 
@@ -1285,7 +1285,7 @@ XF86VidModeGetGammaRampSize(
 
     internal static partial class Functions
     {
-        internal const string X11Library = "libX11";
+        internal const string X11Library = "libX11.so.6";
         internal const string XcursorLibrary = "libXcursor.so.1";
 
         /// <summary>
@@ -1553,7 +1553,7 @@ XF86VidModeGetGammaRampSize(
         [DllImport(X11Library)]
         unsafe public static extern Pixmap XCreateBitmapFromData(Display display, Window d, byte* data, int width, int height);
 
-        [DllImport("libX11", EntryPoint = "XAllocColor")]
+        [DllImport(X11Library, EntryPoint = "XAllocColor")]
         public static extern Status XAllocNamedColor(Display display, Colormap colormap, string color_name, out XColor screen_def_return, out XColor exact_def_return);
     }
     /*

--- a/src/OpenTK/Platform/X11/Bindings/XI.cs
+++ b/src/OpenTK/Platform/X11/Bindings/XI.cs
@@ -38,7 +38,7 @@ namespace OpenTK.Platform.X11
     // Bindings for the XInput2 extension
     internal class XI
     {
-        private const string lib = "libXi";
+        private const string lib = "libXi.so.6";
 
         internal const int XIAllDevices = 0;
         internal const int XIAllMasterDevices = 1;

--- a/src/OpenTK/Platform/X11/Bindings/Xkb.cs
+++ b/src/OpenTK/Platform/X11/Bindings/Xkb.cs
@@ -44,7 +44,7 @@ namespace OpenTK.Platform.X11
 
     internal class Xkb
     {
-        private const string lib = "libX11";
+        private const string lib = "libX11.so.6";
 
         internal const int KeyNameLength = 4;
         internal const int NumModifiers = 8;

--- a/src/OpenTK/Platform/X11/Functions.cs
+++ b/src/OpenTK/Platform/X11/Functions.cs
@@ -42,7 +42,9 @@ namespace OpenTK.Platform.X11
     {
         public static readonly object Lock = API.Lock;
 
-        [DllImport("libX11", EntryPoint = "XOpenDisplay")]
+        private const string lib = "libX11.so.6";
+
+        [DllImport(lib, EntryPoint = "XOpenDisplay")]
         private extern static IntPtr sys_XOpenDisplay(IntPtr display);
         public static IntPtr XOpenDisplay(IntPtr display)
         {
@@ -52,91 +54,91 @@ namespace OpenTK.Platform.X11
             }
         }
 
-        [DllImport("libX11", EntryPoint = "XCloseDisplay")]
+        [DllImport(lib, EntryPoint = "XCloseDisplay")]
         public extern static int XCloseDisplay(IntPtr display);
-        [DllImport("libX11", EntryPoint = "XSynchronize")]
+        [DllImport(lib, EntryPoint = "XSynchronize")]
         public extern static IntPtr XSynchronize(IntPtr display, bool onoff);
 
-        [DllImport("libX11", EntryPoint = "XCreateWindow")]
+        [DllImport(lib, EntryPoint = "XCreateWindow")]
         public extern static IntPtr XCreateWindow(IntPtr display, IntPtr parent, int x, int y, int width, int height, int border_width, int depth, int xclass, IntPtr visual, IntPtr valuemask, ref XSetWindowAttributes attributes);
         
-        [DllImport("libX11", EntryPoint = "XCreateWindow")]
+        [DllImport(lib, EntryPoint = "XCreateWindow")]
         public unsafe extern static IntPtr XCreateWindow(IntPtr display, IntPtr parent, int x, int y, int width, int height, int border_width, int depth, int xclass, IntPtr visual, IntPtr valuemask, XSetWindowAttributes* attributes);
 
-        [DllImport("libX11", EntryPoint = "XCreateSimpleWindow")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XCreateSimpleWindow")]//, CLSCompliant(false)]
         public extern static IntPtr XCreateSimpleWindow(IntPtr display, IntPtr parent, int x, int y, int width, int height, int border_width, UIntPtr border, UIntPtr background);
-        [DllImport("libX11", EntryPoint = "XCreateSimpleWindow")]
+        [DllImport(lib, EntryPoint = "XCreateSimpleWindow")]
         public extern static IntPtr XCreateSimpleWindow(IntPtr display, IntPtr parent, int x, int y, int width, int height, int border_width, IntPtr border, IntPtr background);
 
-        [DllImport("libX11", EntryPoint = "XMapWindow")]
+        [DllImport(lib, EntryPoint = "XMapWindow")]
         public extern static int XMapWindow(IntPtr display, IntPtr window);
-        [DllImport("libX11", EntryPoint = "XUnmapWindow")]
+        [DllImport(lib, EntryPoint = "XUnmapWindow")]
         public extern static int XUnmapWindow(IntPtr display, IntPtr window);
-        [DllImport("libX11", EntryPoint = "XMapSubwindows")]
+        [DllImport(lib, EntryPoint = "XMapSubwindows")]
         public extern static int XMapSubindows(IntPtr display, IntPtr window);
-        [DllImport("libX11", EntryPoint = "XUnmapSubwindows")]
+        [DllImport(lib, EntryPoint = "XUnmapSubwindows")]
         public extern static int XUnmapSubwindows(IntPtr display, IntPtr window);
-        [DllImport("libX11", EntryPoint = "XRootWindow")]
+        [DllImport(lib, EntryPoint = "XRootWindow")]
         public extern static IntPtr XRootWindow(IntPtr display, int screen_number);
 
-        [DllImport("libX11", EntryPoint = "XNextEvent")]
+        [DllImport(lib, EntryPoint = "XNextEvent")]
         public extern static IntPtr XNextEvent(IntPtr display, ref XEvent xevent);
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static Bool XWindowEvent(Display display, Window w, EventMask event_mask, ref XEvent event_return);
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static Bool XCheckWindowEvent(Display display, Window w, EventMask event_mask, ref XEvent event_return);
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static Bool XCheckTypedWindowEvent(Display display, Window w, XEventName event_type, ref XEvent event_return);
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static Bool XCheckTypedEvent(Display display, XEventName event_type, out XEvent event_return);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public delegate Bool EventPredicate(IntPtr display, ref XEvent e, IntPtr arg);
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static Bool XIfEvent(Display display, ref XEvent e, IntPtr predicate, IntPtr arg );
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static Bool XCheckIfEvent(Display display, ref XEvent e, IntPtr predicate, IntPtr arg );
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static int XConnectionNumber(IntPtr diplay);
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static int XPending(IntPtr diplay);
 
-        [DllImport("libX11", EntryPoint = "XSelectInput")]
+        [DllImport(lib, EntryPoint = "XSelectInput")]
         public extern static int XSelectInput(IntPtr display, IntPtr window, IntPtr mask);
 
-        [DllImport("libX11", EntryPoint = "XDestroyWindow")]
+        [DllImport(lib, EntryPoint = "XDestroyWindow")]
         public extern static int XDestroyWindow(IntPtr display, IntPtr window);
 
-        [DllImport("libX11", EntryPoint = "XReparentWindow")]
+        [DllImport(lib, EntryPoint = "XReparentWindow")]
         public extern static int XReparentWindow(IntPtr display, IntPtr window, IntPtr parent, int x, int y);
 
-        [DllImport("libX11", EntryPoint = "XMoveResizeWindow")]
+        [DllImport(lib, EntryPoint = "XMoveResizeWindow")]
         public extern static int XMoveResizeWindow(IntPtr display, IntPtr window, int x, int y, int width, int height);
 
-        [DllImport("libX11", EntryPoint = "XMoveWindow")]
+        [DllImport(lib, EntryPoint = "XMoveWindow")]
         public extern static int XMoveWindow(IntPtr display, IntPtr w, int x, int y);
 
-        [DllImport("libX11", EntryPoint = "XResizeWindow")]
+        [DllImport(lib, EntryPoint = "XResizeWindow")]
         public extern static int XResizeWindow(IntPtr display, IntPtr window, int width, int height);
 
-        [DllImport("libX11", EntryPoint = "XGetWindowAttributes")]
+        [DllImport(lib, EntryPoint = "XGetWindowAttributes")]
         public extern static int XGetWindowAttributes(IntPtr display, IntPtr window, ref XWindowAttributes attributes);
 
-        [DllImport("libX11", EntryPoint = "XFlush")]
+        [DllImport(lib, EntryPoint = "XFlush")]
         public extern static int XFlush(IntPtr display);
 
-        [DllImport("libX11", EntryPoint = "XSetWMName")]
+        [DllImport(lib, EntryPoint = "XSetWMName")]
         public extern static int XSetWMName(IntPtr display, IntPtr window, ref XTextProperty text_prop);
 
-        [DllImport("libX11", EntryPoint = "XStoreName")]
+        [DllImport(lib, EntryPoint = "XStoreName")]
         public extern static int XStoreName(IntPtr display, IntPtr window, string window_name);
 
-        [DllImport("libX11", EntryPoint = "XFetchName")]
+        [DllImport(lib, EntryPoint = "XFetchName")]
         public extern static int XFetchName(IntPtr display, IntPtr window, ref IntPtr window_name);
 
-        [DllImport("libX11", EntryPoint = "XSendEvent")]
+        [DllImport(lib, EntryPoint = "XSendEvent")]
         public extern static int XSendEvent(IntPtr display, IntPtr window, bool propagate, IntPtr event_mask, ref XEvent send_event);
 
         public static int XSendEvent(IntPtr display, IntPtr window, bool propagate, EventMask event_mask, ref XEvent send_event)
@@ -144,296 +146,296 @@ namespace OpenTK.Platform.X11
             return XSendEvent(display, window, propagate, new IntPtr((int)event_mask), ref send_event);
         }
 
-        [DllImport("libX11", EntryPoint = "XQueryTree")]
+        [DllImport(lib, EntryPoint = "XQueryTree")]
         public extern static int XQueryTree(IntPtr display, IntPtr window, out IntPtr root_return, out IntPtr parent_return, out IntPtr children_return, out int nchildren_return);
 
-        [DllImport("libX11", EntryPoint = "XFree")]
+        [DllImport(lib, EntryPoint = "XFree")]
         public extern static int XFree(IntPtr data);
 
-        [DllImport("libX11", EntryPoint = "XRaiseWindow")]
+        [DllImport(lib, EntryPoint = "XRaiseWindow")]
         public extern static int XRaiseWindow(IntPtr display, IntPtr window);
 
-        [DllImport("libX11", EntryPoint = "XLowerWindow")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XLowerWindow")]//, CLSCompliant(false)]
         public extern static uint XLowerWindow(IntPtr display, IntPtr window);
 
-        [DllImport("libX11", EntryPoint = "XConfigureWindow")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XConfigureWindow")]//, CLSCompliant(false)]
         public extern static uint XConfigureWindow(IntPtr display, IntPtr window, ChangeWindowAttributes value_mask, ref XWindowChanges values);
 
-        [DllImport("libX11", EntryPoint = "XInternAtom")]
+        [DllImport(lib, EntryPoint = "XInternAtom")]
         public extern static IntPtr XInternAtom(IntPtr display, string atom_name, bool only_if_exists);
 
-        [DllImport("libX11", EntryPoint = "XInternAtoms")]
+        [DllImport(lib, EntryPoint = "XInternAtoms")]
         public extern static int XInternAtoms(IntPtr display, string[] atom_names, int atom_count, bool only_if_exists, IntPtr[] atoms);
 
-        [DllImport("libX11", EntryPoint = "XGetAtomName")]
+        [DllImport(lib, EntryPoint = "XGetAtomName")]
         public extern static IntPtr XGetAtomName(IntPtr display, IntPtr atom);
 
-        [DllImport("libX11", EntryPoint = "XSetWMProtocols")]
+        [DllImport(lib, EntryPoint = "XSetWMProtocols")]
         public extern static int XSetWMProtocols(IntPtr display, IntPtr window, IntPtr[] protocols, int count);
 
-        [DllImport("libX11", EntryPoint = "XGrabPointer")]
+        [DllImport(lib, EntryPoint = "XGrabPointer")]
         public extern static int XGrabPointer(IntPtr display, IntPtr window, bool owner_events, EventMask event_mask, GrabMode pointer_mode, GrabMode keyboard_mode, IntPtr confine_to, IntPtr cursor, IntPtr timestamp);
 
-        [DllImport("libX11", EntryPoint = "XUngrabPointer")]
+        [DllImport(lib, EntryPoint = "XUngrabPointer")]
         public extern static int XUngrabPointer(IntPtr display, IntPtr timestamp);
 
-        [DllImport("libX11", EntryPoint = "XGrabButton")]
+        [DllImport(lib, EntryPoint = "XGrabButton")]
         public extern static int XGrabButton(IntPtr display,
             int button, uint modifiers, Window grab_window,
             Bool owner_events, EventMask event_mask,
             GrabMode pointer_mode, GrabMode keyboard_mode,
             Window confine_to, Cursor cursor);
 
-        [DllImport("libX11", EntryPoint = "XUngrabButton")]
+        [DllImport(lib, EntryPoint = "XUngrabButton")]
         public extern static int XUngrabButton(IntPtr display, uint button, uint
               modifiers, Window grab_window);
 
-        [DllImport("libX11", EntryPoint = "XQueryPointer")]
+        [DllImport(lib, EntryPoint = "XQueryPointer")]
         public extern static bool XQueryPointer(IntPtr display, IntPtr window, out IntPtr root, out IntPtr child, out int root_x, out int root_y, out int win_x, out int win_y, out int keys_buttons);
 
-        [DllImport("libX11", EntryPoint = "XTranslateCoordinates")]
+        [DllImport(lib, EntryPoint = "XTranslateCoordinates")]
         public extern static bool XTranslateCoordinates(IntPtr display, IntPtr src_w, IntPtr dest_w, int src_x, int src_y, out int intdest_x_return, out int dest_y_return, out IntPtr child_return);
 
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static int XGrabKey(IntPtr display, int keycode, uint modifiers,
             Window grab_window, bool owner_events, GrabMode pointer_mode, GrabMode keyboard_mode);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static int XUngrabKey(IntPtr display, int keycode, uint modifiers, Window grab_window);
 
-        [DllImport("libX11", EntryPoint = "XGrabKeyboard")]
+        [DllImport(lib, EntryPoint = "XGrabKeyboard")]
         public extern static int XGrabKeyboard(IntPtr display, IntPtr window, bool owner_events,
             GrabMode pointer_mode, GrabMode keyboard_mode, IntPtr timestamp);
 
-        [DllImport("libX11", EntryPoint = "XUngrabKeyboard")]
+        [DllImport(lib, EntryPoint = "XUngrabKeyboard")]
         public extern static int XUngrabKeyboard(IntPtr display, IntPtr timestamp);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static int XAllowEvents(IntPtr display, EventMode event_mode, Time time);
 
-        [DllImport("libX11", EntryPoint = "XGetGeometry")]
+        [DllImport(lib, EntryPoint = "XGetGeometry")]
         public extern static bool XGetGeometry(IntPtr display, IntPtr window, out IntPtr root, out int x, out int y, out int width, out int height, out int border_width, out int depth);
 
-        [DllImport("libX11", EntryPoint = "XGetGeometry")]
+        [DllImport(lib, EntryPoint = "XGetGeometry")]
         public extern static bool XGetGeometry(IntPtr display, IntPtr window, IntPtr root, out int x, out int y, out int width, out int height, IntPtr border_width, IntPtr depth);
 
-        [DllImport("libX11", EntryPoint = "XGetGeometry")]
+        [DllImport(lib, EntryPoint = "XGetGeometry")]
         public extern static bool XGetGeometry(IntPtr display, IntPtr window, IntPtr root, out int x, out int y, IntPtr width, IntPtr height, IntPtr border_width, IntPtr depth);
 
-        [DllImport("libX11", EntryPoint = "XGetGeometry")]
+        [DllImport(lib, EntryPoint = "XGetGeometry")]
         public extern static bool XGetGeometry(IntPtr display, IntPtr window, IntPtr root, IntPtr x, IntPtr y, out int width, out int height, IntPtr border_width, IntPtr depth);
 
-        [DllImport("libX11", EntryPoint = "XWarpPointer")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XWarpPointer")]//, CLSCompliant(false)]
         public extern static uint XWarpPointer(IntPtr display, IntPtr src_w, IntPtr dest_w, int src_x, int src_y, uint src_width, uint src_height, int dest_x, int dest_y);
 
-        [DllImport("libX11", EntryPoint = "XClearWindow")]
+        [DllImport(lib, EntryPoint = "XClearWindow")]
         public extern static int XClearWindow(IntPtr display, IntPtr window);
 
-        [DllImport("libX11", EntryPoint = "XClearArea")]
+        [DllImport(lib, EntryPoint = "XClearArea")]
         public extern static int XClearArea(IntPtr display, IntPtr window, int x, int y, int width, int height, bool exposures);
 
         // Colormaps
-        [DllImport("libX11", EntryPoint = "XDefaultScreenOfDisplay")]
+        [DllImport(lib, EntryPoint = "XDefaultScreenOfDisplay")]
         public extern static IntPtr XDefaultScreenOfDisplay(IntPtr display);
 
-        [DllImport("libX11", EntryPoint = "XScreenNumberOfScreen")]
+        [DllImport(lib, EntryPoint = "XScreenNumberOfScreen")]
         public extern static int XScreenNumberOfScreen(IntPtr display, IntPtr Screen);
 
-        [DllImport("libX11", EntryPoint = "XDefaultVisual")]
+        [DllImport(lib, EntryPoint = "XDefaultVisual")]
         public extern static IntPtr XDefaultVisual(IntPtr display, int screen_number);
 
-        [DllImport("libX11", EntryPoint = "XDefaultDepth")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XDefaultDepth")]//, CLSCompliant(false)]
         public extern static uint XDefaultDepth(IntPtr display, int screen_number);
 
-        [DllImport("libX11", EntryPoint = "XDefaultScreen")]
+        [DllImport(lib, EntryPoint = "XDefaultScreen")]
         public extern static int XDefaultScreen(IntPtr display);
 
-        [DllImport("libX11", EntryPoint = "XDefaultColormap")]
+        [DllImport(lib, EntryPoint = "XDefaultColormap")]
         public extern static IntPtr XDefaultColormap(IntPtr display, int screen_number);
 
-        [DllImport("libX11", EntryPoint = "XLookupColor")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XLookupColor")]//, CLSCompliant(false)]
         public extern static int XLookupColor(IntPtr display, IntPtr Colormap, string Coloranem, ref XColor exact_def_color, ref XColor screen_def_color);
 
-        [DllImport("libX11", EntryPoint = "XAllocColor")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XAllocColor")]//, CLSCompliant(false)]
         public extern static int XAllocColor(IntPtr display, IntPtr Colormap, ref XColor colorcell_def);
 
-        [DllImport("libX11", EntryPoint = "XSetTransientForHint")]
+        [DllImport(lib, EntryPoint = "XSetTransientForHint")]
         public extern static int XSetTransientForHint(IntPtr display, IntPtr window, IntPtr prop_window);
 
-        [DllImport("libX11", EntryPoint = "XChangeProperty")]
+        [DllImport(lib, EntryPoint = "XChangeProperty")]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, ref MotifWmHints data, int nelements);
 
-        [DllImport("libX11", EntryPoint = "XChangeProperty")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XChangeProperty")]//, CLSCompliant(false)]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, ref uint value, int nelements);
-        [DllImport("libX11", EntryPoint = "XChangeProperty")]
+        [DllImport(lib, EntryPoint = "XChangeProperty")]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, ref int value, int nelements);
 
-        [DllImport("libX11", EntryPoint = "XChangeProperty")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XChangeProperty")]//, CLSCompliant(false)]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, ref IntPtr value, int nelements);
 
-        [DllImport("libX11", EntryPoint = "XChangeProperty")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XChangeProperty")]//, CLSCompliant(false)]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, uint[] data, int nelements);
 
-        [DllImport("libX11", EntryPoint = "XChangeProperty")]
+        [DllImport(lib, EntryPoint = "XChangeProperty")]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, int[] data, int nelements);
 
-        [DllImport("libX11", EntryPoint = "XChangeProperty")]
+        [DllImport(lib, EntryPoint = "XChangeProperty")]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, IntPtr[] data, int nelements);
 
-        [DllImport("libX11", EntryPoint = "XChangeProperty")]
+        [DllImport(lib, EntryPoint = "XChangeProperty")]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, IntPtr atoms, int nelements);
 
-        [DllImport("libX11", EntryPoint = "XChangeProperty", CharSet = CharSet.Ansi)]
+        [DllImport(lib, EntryPoint = "XChangeProperty", CharSet = CharSet.Ansi)]
         public extern static int XChangeProperty(IntPtr display, IntPtr window, IntPtr property, IntPtr type, int format, PropertyMode mode, string text, int text_length);
 
-        [DllImport("libX11", EntryPoint = "XDeleteProperty")]
+        [DllImport(lib, EntryPoint = "XDeleteProperty")]
         public extern static int XDeleteProperty(IntPtr display, IntPtr window, IntPtr property);
 
         // Drawing
-        [DllImport("libX11", EntryPoint = "XCreateGC")]
+        [DllImport(lib, EntryPoint = "XCreateGC")]
         public extern static IntPtr XCreateGC(IntPtr display, IntPtr window, IntPtr valuemask, XGCValues[] values);
 
-        [DllImport("libX11", EntryPoint = "XFreeGC")]
+        [DllImport(lib, EntryPoint = "XFreeGC")]
         public extern static int XFreeGC(IntPtr display, IntPtr gc);
 
-        [DllImport("libX11", EntryPoint = "XSetFunction")]
+        [DllImport(lib, EntryPoint = "XSetFunction")]
         public extern static int XSetFunction(IntPtr display, IntPtr gc, GXFunction function);
 
-        [DllImport("libX11", EntryPoint = "XSetLineAttributes")]
+        [DllImport(lib, EntryPoint = "XSetLineAttributes")]
         public extern static int XSetLineAttributes(IntPtr display, IntPtr gc, int line_width, GCLineStyle line_style, GCCapStyle cap_style, GCJoinStyle join_style);
 
-        [DllImport("libX11", EntryPoint = "XDrawLine")]
+        [DllImport(lib, EntryPoint = "XDrawLine")]
         public extern static int XDrawLine(IntPtr display, IntPtr drawable, IntPtr gc, int x1, int y1, int x2, int y2);
 
-        [DllImport("libX11", EntryPoint = "XDrawRectangle")]
+        [DllImport(lib, EntryPoint = "XDrawRectangle")]
         public extern static int XDrawRectangle(IntPtr display, IntPtr drawable, IntPtr gc, int x1, int y1, int width, int height);
 
-        [DllImport("libX11", EntryPoint = "XFillRectangle")]
+        [DllImport(lib, EntryPoint = "XFillRectangle")]
         public extern static int XFillRectangle(IntPtr display, IntPtr drawable, IntPtr gc, int x1, int y1, int width, int height);
 
-        [DllImport("libX11", EntryPoint = "XSetWindowBackground")]
+        [DllImport(lib, EntryPoint = "XSetWindowBackground")]
         public extern static int XSetWindowBackground(IntPtr display, IntPtr window, IntPtr background);
 
-        [DllImport("libX11", EntryPoint = "XCopyArea")]
+        [DllImport(lib, EntryPoint = "XCopyArea")]
         public extern static int XCopyArea(IntPtr display, IntPtr src, IntPtr dest, IntPtr gc, int src_x, int src_y, int width, int height, int dest_x, int dest_y);
 
-        [DllImport("libX11", EntryPoint = "XGetWindowProperty")]
+        [DllImport(lib, EntryPoint = "XGetWindowProperty")]
         public extern static int XGetWindowProperty(IntPtr display, IntPtr window, IntPtr atom, IntPtr long_offset, IntPtr long_length, bool delete, IntPtr req_type, out IntPtr actual_type, out int actual_format, out IntPtr nitems, out IntPtr bytes_after, ref IntPtr prop);
 
-        [DllImport("libX11", EntryPoint = "XSetInputFocus")]
+        [DllImport(lib, EntryPoint = "XSetInputFocus")]
         public extern static int XSetInputFocus(IntPtr display, IntPtr window, RevertTo revert_to, IntPtr time);
 
-        [DllImport("libX11", EntryPoint = "XIconifyWindow")]
+        [DllImport(lib, EntryPoint = "XIconifyWindow")]
         public extern static int XIconifyWindow(IntPtr display, IntPtr window, int screen_number);
 
-        [DllImport("libX11", EntryPoint = "XDefineCursor")]
+        [DllImport(lib, EntryPoint = "XDefineCursor")]
         public extern static int XDefineCursor(IntPtr display, IntPtr window, IntPtr cursor);
 
-        [DllImport("libX11", EntryPoint = "XUndefineCursor")]
+        [DllImport(lib, EntryPoint = "XUndefineCursor")]
         public extern static int XUndefineCursor(IntPtr display, IntPtr window);
 
-        [DllImport("libX11", EntryPoint = "XFreeCursor")]
+        [DllImport(lib, EntryPoint = "XFreeCursor")]
         public extern static int XFreeCursor(IntPtr display, IntPtr cursor);
 
-        [DllImport("libX11", EntryPoint = "XCreateFontCursor")]
+        [DllImport(lib, EntryPoint = "XCreateFontCursor")]
         public extern static IntPtr XCreateFontCursor(IntPtr display, CursorFontShape shape);
 
-        [DllImport("libX11", EntryPoint = "XCreatePixmapCursor")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XCreatePixmapCursor")]//, CLSCompliant(false)]
         public extern static IntPtr XCreatePixmapCursor(IntPtr display, IntPtr source, IntPtr mask, ref XColor foreground_color, ref XColor background_color, int x_hot, int y_hot);
 
-        [DllImport("libX11", EntryPoint = "XCreatePixmapFromBitmapData")]
+        [DllImport(lib, EntryPoint = "XCreatePixmapFromBitmapData")]
         public extern static IntPtr XCreatePixmapFromBitmapData(IntPtr display, IntPtr drawable, byte[] data, int width, int height, IntPtr fg, IntPtr bg, int depth);
 
-        [DllImport("libX11", EntryPoint = "XCreatePixmap")]
+        [DllImport(lib, EntryPoint = "XCreatePixmap")]
         public extern static IntPtr XCreatePixmap(IntPtr display, IntPtr d, int width, int height, int depth);
 
-        [DllImport("libX11", EntryPoint = "XFreePixmap")]
+        [DllImport(lib, EntryPoint = "XFreePixmap")]
         public extern static IntPtr XFreePixmap(IntPtr display, IntPtr pixmap);
 
-        [DllImport("libX11", EntryPoint = "XQueryBestCursor")]
+        [DllImport(lib, EntryPoint = "XQueryBestCursor")]
         public extern static int XQueryBestCursor(IntPtr display, IntPtr drawable, int width, int height, out int best_width, out int best_height);
 
-        [DllImport("libX11", EntryPoint = "XQueryExtension")]
+        [DllImport(lib, EntryPoint = "XQueryExtension")]
         public extern static int XQueryExtension(IntPtr display, string extension_name, out int major, out int first_event, out int first_error);
 
-        [DllImport("libX11", EntryPoint = "XWhitePixel")]
+        [DllImport(lib, EntryPoint = "XWhitePixel")]
         public extern static IntPtr XWhitePixel(IntPtr display, int screen_no);
 
-        [DllImport("libX11", EntryPoint = "XBlackPixel")]
+        [DllImport(lib, EntryPoint = "XBlackPixel")]
         public extern static IntPtr XBlackPixel(IntPtr display, int screen_no);
 
-        [DllImport("libX11", EntryPoint = "XGrabServer")]
+        [DllImport(lib, EntryPoint = "XGrabServer")]
         public extern static void XGrabServer(IntPtr display);
 
-        [DllImport("libX11", EntryPoint = "XUngrabServer")]
+        [DllImport(lib, EntryPoint = "XUngrabServer")]
         public extern static void XUngrabServer(IntPtr display);
 
-        [DllImport("libX11", EntryPoint = "XGetWMNormalHints")]
+        [DllImport(lib, EntryPoint = "XGetWMNormalHints")]
         public extern static int XGetWMNormalHints(IntPtr display, IntPtr window, ref XSizeHints hints, out IntPtr supplied_return);
 
-        [DllImport("libX11", EntryPoint = "XSetWMNormalHints")]
+        [DllImport(lib, EntryPoint = "XSetWMNormalHints")]
         public extern static void XSetWMNormalHints(IntPtr display, IntPtr window, ref XSizeHints hints);
 
-        [DllImport("libX11", EntryPoint = "XSetZoomHints")]
+        [DllImport(lib, EntryPoint = "XSetZoomHints")]
         public extern static void XSetZoomHints(IntPtr display, IntPtr window, ref XSizeHints hints);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern IntPtr XGetWMHints(Display display, Window w); // returns XWMHints*
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XSetWMHints(Display display, Window w, ref XWMHints wmhints);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern IntPtr XAllocWMHints();
 
-        [DllImport("libX11", EntryPoint = "XGetIconSizes")]
+        [DllImport(lib, EntryPoint = "XGetIconSizes")]
         public extern static int XGetIconSizes(IntPtr display, IntPtr window, out IntPtr size_list, out int count);
 
-        [DllImport("libX11", EntryPoint = "XSetErrorHandler")]
+        [DllImport(lib, EntryPoint = "XSetErrorHandler")]
         public extern static IntPtr XSetErrorHandler(XErrorHandler error_handler);
 
-        [DllImport("libX11", EntryPoint = "XGetErrorText")]
+        [DllImport(lib, EntryPoint = "XGetErrorText")]
         public extern static IntPtr XGetErrorText(IntPtr display, byte code, StringBuilder buffer, int length);
 
-        [DllImport("libX11", EntryPoint = "XInitThreads")]
+        [DllImport(lib, EntryPoint = "XInitThreads")]
         public extern static int XInitThreads();
 
-        [DllImport("libX11", EntryPoint = "XConvertSelection")]
+        [DllImport(lib, EntryPoint = "XConvertSelection")]
         public extern static int XConvertSelection(IntPtr display, IntPtr selection, IntPtr target, IntPtr property, IntPtr requestor, IntPtr time);
 
-        [DllImport("libX11", EntryPoint = "XGetSelectionOwner")]
+        [DllImport(lib, EntryPoint = "XGetSelectionOwner")]
         public extern static IntPtr XGetSelectionOwner(IntPtr display, IntPtr selection);
 
-        [DllImport("libX11", EntryPoint = "XSetSelectionOwner")]
+        [DllImport(lib, EntryPoint = "XSetSelectionOwner")]
         public extern static int XSetSelectionOwner(IntPtr display, IntPtr selection, IntPtr owner, IntPtr time);
 
-        [DllImport("libX11", EntryPoint = "XSetPlaneMask")]
+        [DllImport(lib, EntryPoint = "XSetPlaneMask")]
         public extern static int XSetPlaneMask(IntPtr display, IntPtr gc, IntPtr mask);
 
-        [DllImport("libX11", EntryPoint = "XSetForeground")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XSetForeground")]//, CLSCompliant(false)]
         public extern static int XSetForeground(IntPtr display, IntPtr gc, UIntPtr foreground);
-        [DllImport("libX11", EntryPoint = "XSetForeground")]
+        [DllImport(lib, EntryPoint = "XSetForeground")]
         public extern static int XSetForeground(IntPtr display, IntPtr gc, IntPtr foreground);
 
-        [DllImport("libX11", EntryPoint = "XSetBackground")]//, CLSCompliant(false)]
+        [DllImport(lib, EntryPoint = "XSetBackground")]//, CLSCompliant(false)]
         public extern static int XSetBackground(IntPtr display, IntPtr gc, UIntPtr background);
-        [DllImport("libX11", EntryPoint = "XSetBackground")]
+        [DllImport(lib, EntryPoint = "XSetBackground")]
         public extern static int XSetBackground(IntPtr display, IntPtr gc, IntPtr background);
 
-        [DllImport("libX11", EntryPoint = "XBell")]
+        [DllImport(lib, EntryPoint = "XBell")]
         public extern static int XBell(IntPtr display, int percent);
 
-        [DllImport("libX11", EntryPoint = "XChangeActivePointerGrab")]
+        [DllImport(lib, EntryPoint = "XChangeActivePointerGrab")]
         public extern static int XChangeActivePointerGrab(IntPtr display, EventMask event_mask, IntPtr cursor, IntPtr time);
 
-        [DllImport("libX11", EntryPoint = "XFilterEvent")]
+        [DllImport(lib, EntryPoint = "XFilterEvent")]
         public extern static bool XFilterEvent(ref XEvent xevent, IntPtr window);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public extern static void XPeekEvent(IntPtr display, ref XEvent xevent);
 
-        [DllImport("libX11", EntryPoint = "XGetVisualInfo")]
+        [DllImport(lib, EntryPoint = "XGetVisualInfo")]
         private static extern IntPtr XGetVisualInfoInternal(IntPtr display, IntPtr vinfo_mask, ref XVisualInfo template, out int nitems);
 
         public static IntPtr XGetVisualInfo(IntPtr display, XVisualInfoMask vinfo_mask, ref XVisualInfo template, out int nitems)
@@ -441,67 +443,67 @@ namespace OpenTK.Platform.X11
             return XGetVisualInfoInternal(display, (IntPtr)(int)vinfo_mask, ref template, out nitems);
         }
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern IntPtr XCreateColormap(Display display, Window window, IntPtr visual, int alloc);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XLockDisplay(Display display);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XUnlockDisplay(Display display);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern Status XGetTransientForHint(Display display, Window w, out Window prop_window_return);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XSync(Display display, bool discard);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XAutoRepeatOff(IntPtr display);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XAutoRepeatOn(IntPtr display);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern IntPtr XDefaultRootWindow(IntPtr display);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern int XBitmapBitOrder(Display display);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern IntPtr XCreateImage(Display display, IntPtr visual,
             uint depth, ImageFormat format, int offset, byte[] data, uint width, uint height,
             int bitmap_pad, int bytes_per_line);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern IntPtr XCreateImage(Display display, IntPtr visual,
             uint depth, ImageFormat format, int offset, IntPtr data, uint width, uint height,
             int bitmap_pad, int bytes_per_line);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XPutImage(Display display, IntPtr drawable,
             IntPtr gc, IntPtr image, int src_x, int src_y, int dest_x, int dest_y, uint width, uint height);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern int XLookupString(ref XKeyEvent event_struct, [Out] byte[] buffer_return,
             int bytes_buffer, [Out] KeySym[] keysym_return, IntPtr status_in_out);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern KeyCode XKeysymToKeycode(IntPtr display, KeySym keysym);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern KeySym XKeycodeToKeysym(IntPtr display, KeyCode keycode, int index);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern int XRefreshKeyboardMapping(ref XMappingEvent event_map);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern int XGetEventData(IntPtr display, ref XGenericEventCookie cookie);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XFreeEventData(IntPtr display, ref XGenericEventCookie cookie);
 
-        [DllImport("libX11")]
+        [DllImport(lib)]
         public static extern void XSetClassHint(IntPtr display, IntPtr window, ref XClassHint hint);
 
         private static readonly IntPtr CopyFromParent = IntPtr.Zero;

--- a/src/OpenTK/Platform/X11/X11DisplayDevice.cs
+++ b/src/OpenTK/Platform/X11/X11DisplayDevice.cs
@@ -398,7 +398,7 @@ namespace OpenTK.Platform.X11
 
         private static class NativeMethods
         {
-            private const string Xinerama = "libXinerama";
+            private const string Xinerama = "libXinerama.so.1";
 
             [DllImport(Xinerama)]
             public static extern bool XineramaQueryExtension(IntPtr dpy, out int event_basep, out int error_basep);


### PR DESCRIPTION
### Purpose of this PR

This will make it so that linux flavours that don't provide files like libSDL2.so still function, this will also break SDL2 on windows and macos, and X11 on macos, but those are not being used.

### Testing status

Tested on a fresh ubuntu 18.04 install