### PR TITLE
Android detection and packaging

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,10 @@ build_script:
 after_build:
   - cmd: dotnet pack src/osuTK/osuTK.NS20.csproj -c:Release --include-symbols /p:Version=%APPVEYOR_BUILD_VERSION%
   - cmd: msbuild /t:pack src/osuTK.iOS/osuTK.iOS.csproj /p:Configuration=Release /p:IncludeSymbols=True /p:Version=%APPVEYOR_BUILD_VERSION%
+  - cmd: msbuild /t:pack src/osuTK.Android/osuTK.Android.csproj /p:Configuration=Release /p:IncludeSymbols=True /p:Version=%APPVEYOR_BUILD_VERSION%
 test: off
 version: 1.0.{build}
 artifacts:
   - path: 'src\osuTK\bin\Release\*.nupkg'
   - path: 'src\osuTK.iOS\bin\Release\*.nupkg'
+  - path: 'src\osuTK.Android\bin\Release\*.nupkg'

--- a/src/osuTK.Android/AndroidDisplayDeviceDriver.cs
+++ b/src/osuTK.Android/AndroidDisplayDeviceDriver.cs
@@ -5,11 +5,12 @@
  * See license.txt for licensing detailed licensing details.
  */
 
+using osuTK.Platform;
 using System.Collections.Generic;
 
-namespace osuTK.Platform.Android
+namespace osuTK.Android
 {
-    internal class AndroidDisplayDeviceDriver : IDisplayDeviceDriver
+    public class AndroidDisplayDeviceDriver : IDisplayDeviceDriver
     {
         private static DisplayDevice dev;
         static AndroidDisplayDeviceDriver ()

--- a/src/osuTK.Android/AndroidDisplayDeviceDriver.cs
+++ b/src/osuTK.Android/AndroidDisplayDeviceDriver.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace osuTK.Android
 {
-    public class AndroidDisplayDeviceDriver : IDisplayDeviceDriver
+    public sealed class AndroidDisplayDeviceDriver : IDisplayDeviceDriver
     {
         private static DisplayDevice dev;
         static AndroidDisplayDeviceDriver ()

--- a/src/osuTK.Android/AndroidFactory.cs
+++ b/src/osuTK.Android/AndroidFactory.cs
@@ -8,10 +8,11 @@
 using System;
 using osuTK.Graphics;
 using osuTK.Platform;
+using osuTK.Platform.Egl;
 
 namespace osuTK.Android
 {
-    internal sealed class AndroidFactory : PlatformFactoryBase
+    public class AndroidFactory : PlatformFactoryBase
     {
         public override IGraphicsContext CreateGLContext(GraphicsMode mode, IWindowInfo window, IGraphicsContext shareContext, bool directRendering, int major, int minor, GraphicsContextFlags flags)
         {
@@ -29,7 +30,7 @@ namespace osuTK.Android
         {
             return (GraphicsContext.GetCurrentContextDelegate)delegate
             {
-                return new ContextHandle(Egl.Egl.GetCurrentContext());
+                return new ContextHandle(Egl.GetCurrentContext());
             };
         }
 

--- a/src/osuTK.Android/AndroidFactory.cs
+++ b/src/osuTK.Android/AndroidFactory.cs
@@ -12,7 +12,7 @@ using osuTK.Platform.Egl;
 
 namespace osuTK.Android
 {
-    public class AndroidFactory : PlatformFactoryBase
+    public sealed class AndroidFactory : PlatformFactoryBase
     {
         public override IGraphicsContext CreateGLContext(GraphicsMode mode, IWindowInfo window, IGraphicsContext shareContext, bool directRendering, int major, int minor, GraphicsContextFlags flags)
         {

--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -26,6 +26,7 @@ using Android.Runtime;
 using Android.Graphics;
 using osuTK.Platform.Egl;
 using SurfaceType = Android.Views.SurfaceType;
+using Size = System.Drawing.Size;
 
 namespace osuTK.Android
 {

--- a/src/osuTK.Android/AndroidGraphicsContext.cs
+++ b/src/osuTK.Android/AndroidGraphicsContext.cs
@@ -14,9 +14,10 @@ using Javax.Microedition.Khronos.Egl;
 
 using osuTK.Graphics;
 using osuTK.Platform.Egl;
+using osuTK.Platform;
 
 namespace osuTK.Android {
-    internal class AndroidGraphicsContext : EglContext
+    public class AndroidGraphicsContext : EglContext
     {
         public AndroidGraphicsContext(GraphicsMode mode, EglWindowInfo window, IGraphicsContext sharedContext,
             int major, int minor, GraphicsContextFlags flags)

--- a/src/osuTK.Android/AndroidGraphicsContext.cs
+++ b/src/osuTK.Android/AndroidGraphicsContext.cs
@@ -17,7 +17,7 @@ using osuTK.Platform.Egl;
 using osuTK.Platform;
 
 namespace osuTK.Android {
-    public class AndroidGraphicsContext : EglContext
+    public sealed class AndroidGraphicsContext : EglContext
     {
         public AndroidGraphicsContext(GraphicsMode mode, EglWindowInfo window, IGraphicsContext sharedContext,
             int major, int minor, GraphicsContextFlags flags)

--- a/src/osuTK.Android/GameViewBase.cs
+++ b/src/osuTK.Android/GameViewBase.cs
@@ -23,6 +23,8 @@ using Android.Runtime;
 using Java.Util;
 using osuTK.Input;
 
+using Size = System.Drawing.Size;
+
 namespace osuTK
 {
     [Register ("opentk_1_1/GameViewBase")]
@@ -1139,7 +1141,7 @@ namespace osuTK
             set { throw new NotSupportedException(); }
         }
 
-        public bool CursorGrabbed { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool CursorGrabbed { get => true; set { } }
 
         event EventHandler<EventArgs> INativeWindow.IconChanged
         {

--- a/src/osuTK.Android/GameViewBase.cs
+++ b/src/osuTK.Android/GameViewBase.cs
@@ -1139,6 +1139,8 @@ namespace osuTK
             set { throw new NotSupportedException(); }
         }
 
+        public bool CursorGrabbed { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
         event EventHandler<EventArgs> INativeWindow.IconChanged
         {
             add { throw new NotSupportedException(); }

--- a/src/osuTK.Android/osuTK.Android.csproj
+++ b/src/osuTK.Android/osuTK.Android.csproj
@@ -1,15 +1,12 @@
 <Project Sdk="MSBuild.Sdk.Extras/1.6.55">
   <Import Project="..\Common.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
-    <PackageVersion>1.0.8</PackageVersion>
     <PackageId>ppy.osuTK.Android</PackageId>
     <Title>ppy.osuTK.Android</Title>
     <RootNamespace>osuTK.Android</RootNamespace>
     <AssemblyName>osuTK.Android</AssemblyName>
-    <OutputPath>bin/$(Configuration)/</OutputPath>
+    <TargetFramework>monoandroid23</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -20,5 +17,4 @@
   <ItemGroup>
     <ProjectReference Include="..\osuTK\osuTK.NS20.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/src/osuTK.Android/osuTK.Android.csproj
+++ b/src/osuTK.Android/osuTK.Android.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/1.6.55">
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.55">
   <Import Project="..\Common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -6,7 +6,7 @@
     <Title>ppy.osuTK.Android</Title>
     <RootNamespace>osuTK.Android</RootNamespace>
     <AssemblyName>osuTK.Android</AssemblyName>
-    <TargetFramework>monoandroid23</TargetFramework>
+    <TargetFramework>monoandroid50</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/osuTK/Configuration.cs
+++ b/src/osuTK/Configuration.cs
@@ -260,12 +260,8 @@ namespace osuTK
 
         private static bool DetectAndroid()
         {
-            AppDomain currentDomain = AppDomain.CurrentDomain;
-
-            Assembly[] assems = currentDomain.GetAssemblies();
-
             //List the assemblies in the current application domain.
-            foreach (Assembly assem in assems)
+            foreach (Assembly assem in AppDomain.CurrentDomain.GetAssemblies())
             {
                 if (assem.ToString().Contains("Mono.Android"))
                 {
@@ -285,6 +281,7 @@ namespace osuTK
                     RunningOnMono = DetectMono();
                     RunningOnWindows = DetectWindows();
                     RunningOnAndroid = DetectAndroid();
+
                     if (!RunningOnWindows)
                     {
                         DetectUnix(out runningOnUnix, out runningOnLinux, out runningOnMacOS, out runningOnIOS);

--- a/src/osuTK/Platform/Factory.cs
+++ b/src/osuTK/Platform/Factory.cs
@@ -122,17 +122,18 @@ namespace osuTK.Platform
                 else if (Configuration.RunningOnAndroid)
                 {
                     Embedded = CreateFactoryForType("osuTK.Android.AndroidFactory");
+                    Angle = new UnsupportedPlatform();
                 }
                 else
                 {
                     Embedded = new UnsupportedPlatform();
                 }
 
-#if ANDROID
-                Angle = new UnsupportedPlatform();
-#else
-                Angle = new Egl.EglAnglePlatformFactory(Embedded);
-#endif
+                if (!Configuration.RunningOnAndroid)
+                {
+                    Angle = new Egl.EglAnglePlatformFactory(Embedded);
+                }
+                
             }
             else
             {


### PR DESCRIPTION
### Purpose of this PR

* Adds proper Android detection (no more proprocessing directives).
* Creates NuGet packages for Android.

### Testing status

* Testing currently in progress with an Android port of osu-framework to ensure the correct Factory is loaded. So far, detection is working.

### Comments

* If osuTK detects Android, `RunningOnLinux` is set to false to bypass SDL2 and X11 detection, and ensures we never load `LinuxFactory`. This does not affect desktop Linux machines.
