### PR TITLE
Change signature of GetStates to avoid allocation

### DIFF
--- a/src/osuTK/Input/IJoystickDriver2.cs
+++ b/src/osuTK/Input/IJoystickDriver2.cs
@@ -26,13 +26,14 @@
 //
 
 using System;
+using System.Collections.Generic;
 
 namespace osuTK.Input
 {
     public interface IJoystickDriver2
     {
         JoystickState GetState(int index);
-        JoystickState[] GetStates();
+        void GetStates(List<JoystickState> result);
         JoystickCapabilities GetCapabilities(int index);
         Guid GetGuid(int index);
     }

--- a/src/osuTK/Input/IKeyboardDriver2.cs
+++ b/src/osuTK/Input/IKeyboardDriver2.cs
@@ -1,4 +1,6 @@
-﻿namespace osuTK.Input
+﻿using System.Collections.Generic;
+
+namespace osuTK.Input
 {
     public interface IKeyboardDriver2
     {
@@ -18,8 +20,8 @@
         /// <summary>
         /// Retrives <see cref="osuTK.Input.KeyboardState"/> for all keyboard devices.
         /// </summary>
-        /// <returns>An array of <see cref="osuTK.Input.KeyboardState"/> representing the state for the keyboard devices.</returns>
-        KeyboardState[] GetStates();
+        /// <param name="result">All states of the keyboard devices are populated into this list.</param>
+        void GetStates(List<KeyboardState> result);
 
         /// <summary>
         /// Retrieves the device name for the keyboard device.

--- a/src/osuTK/Input/IMouseDriver2.cs
+++ b/src/osuTK/Input/IMouseDriver2.cs
@@ -23,13 +23,15 @@
  // OTHER DEALINGS IN THE SOFTWARE.
  //
 
-namespace osuTK.Input
+ using System.Collections.Generic;
+
+ namespace osuTK.Input
 {
     public interface IMouseDriver2
     {
         MouseState GetState();
         MouseState GetState(int index);
-        MouseState[] GetStates();
+        void GetStates(List<MouseState> result);
         void SetPosition(double x, double y);
         MouseState GetCursorState();
     }

--- a/src/osuTK/Input/Joystick.cs
+++ b/src/osuTK/Input/Joystick.cs
@@ -26,6 +26,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 
 namespace osuTK.Input
 {
@@ -78,10 +79,10 @@ namespace osuTK.Input
         /// <summary>
         /// Retrives <see cref="osuTK.Input.JoystickState"/> for all joystick devices.
         /// </summary>
-        /// <returns>An array of <see cref="osuTK.Input.JoystickState"/> representing the state for the joystick devices.</returns>
-        public static JoystickState[] GetStates()
+        /// <param name="result">All states of the joystick devices are populated into this list.</param>
+        public static void GetStates(List<JoystickState> result)
         {
-            return implementation.GetStates();
+            implementation.GetStates(result);
         }
 
         /// <summary>

--- a/src/osuTK/Input/Keyboard.cs
+++ b/src/osuTK/Input/Keyboard.cs
@@ -72,7 +72,8 @@ namespace osuTK.Input
         /// Retrives <see cref="osuTK.Input.KeyboardState"/> for all keyboard devices.
         /// </summary>
         /// <param name="result">All states of the keyboard devices are populated into this list.</param>
-        public static void GetStates(List<KeyboardState> result) {
+        public static void GetStates(List<KeyboardState> result)
+        {
             lock (SyncRoot)
             {
                 driver.GetStates(result);

--- a/src/osuTK/Input/Keyboard.cs
+++ b/src/osuTK/Input/Keyboard.cs
@@ -24,6 +24,7 @@
  //
 
 using System;
+using System.Collections.Generic;
 
 namespace osuTK.Input
 {
@@ -70,12 +71,11 @@ namespace osuTK.Input
         /// <summary>
         /// Retrives <see cref="osuTK.Input.KeyboardState"/> for all keyboard devices.
         /// </summary>
-        /// <returns>An array of <see cref="osuTK.Input.KeyboardState"/> representing the state for the keyboard devices.</returns>
-        public static KeyboardState[] GetStates()
-        {
+        /// <param name="result">All states of the keyboard devices are populated into this list.</param>
+        public static void GetStates(List<KeyboardState> result) {
             lock (SyncRoot)
             {
-                return driver.GetStates();
+                driver.GetStates(result);
             }
         }
 

--- a/src/osuTK/Input/Mouse.cs
+++ b/src/osuTK/Input/Mouse.cs
@@ -24,6 +24,7 @@
  //
 
 using System;
+using System.Collections.Generic;
 
 namespace osuTK.Input
 {
@@ -82,12 +83,12 @@ namespace osuTK.Input
         /// <summary>
         /// Retrives <see cref="osuTK.Input.MouseState"/> for all mouse device.
         /// </summary>
-        /// <returns>An array of <see cref="osuTK.Input.MouseState"/> representing the state for the mouse devices.</returns>
-        public static MouseState[] GetStates()
+        /// <param name="result">All states of the keyboard devices are populated into this list.</param>
+        public static void GetStates(List<MouseState> result)
         {
             lock (SyncRoot)
             {
-                return driver.GetStates();
+                driver.GetStates(result);
             }
         }
 

--- a/src/osuTK/Platform/Linux/LinuxInput.cs
+++ b/src/osuTK/Platform/Linux/LinuxInput.cs
@@ -26,9 +26,9 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using osuTK.Input;
@@ -600,11 +600,15 @@ namespace osuTK.Platform.Linux
             }
         }
 
-        KeyboardState[] IKeyboardDriver2.GetStates()
+        void IKeyboardDriver2.GetStates(List<KeyboardState> result)
         {
             lock (Sync)
             {
-                return Keyboards.Select(device => device.State).ToArray();
+                result.Clear();
+                foreach (var device in Keyboards)
+                {
+                    result.Add(device.State);
+                }
             }
         }
 
@@ -653,11 +657,15 @@ namespace osuTK.Platform.Linux
             }
         }
 
-        MouseState[] IMouseDriver2.GetStates()
+        void IMouseDriver2.GetStates(List<MouseState> result)
         {
             lock (Sync)
             {
-                return Mice.Select(m => m.State).ToArray();
+                result.Clear();
+                for (int i = 0; i < Mice.Count; i++)
+                {
+                    result.Add(((IMouseDriver2)this).GetState(i));
+                }
             }
         }
 

--- a/src/osuTK/Platform/Linux/LinuxJoystick.cs
+++ b/src/osuTK/Platform/Linux/LinuxJoystick.cs
@@ -27,7 +27,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using osuTK.Input;
 
 namespace osuTK.Platform.Linux
@@ -490,9 +489,13 @@ namespace osuTK.Platform.Linux
             return new JoystickState();
         }
 
-        JoystickState[] IJoystickDriver2.GetStates()
+        void IJoystickDriver2.GetStates(List<JoystickState> result)
         {
-            return Enumerable.Range(0, Sticks.Count).Select(index => ((IJoystickDriver2)this).GetState(index)).ToArray();
+            result.Clear();
+            for (var i = 0; i < Sticks.Count; ++i)
+            {
+                result.Add(((IJoystickDriver2)this).GetState(i));
+            }
         }
 
         JoystickCapabilities IJoystickDriver2.GetCapabilities(int index)

--- a/src/osuTK/Platform/MacOS/HIDInput.cs
+++ b/src/osuTK/Platform/MacOS/HIDInput.cs
@@ -26,7 +26,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using osuTK.Input;
 using osuTK.Platform.Common;
@@ -1004,9 +1003,13 @@ namespace osuTK.Platform.MacOS
             return new MouseState();
         }
 
-        MouseState[] IMouseDriver2.GetStates()
+        void IMouseDriver2.GetStates(List<MouseState> result)
         {
-            return MouseDevices.Select(d => d.State).ToArray();
+            result.Clear();
+            for (int i = 0; i < MouseDevices.Count; i++)
+            {
+                result.Add(((IMouseDriver2)this).GetState(i));
+            }
         }
 
         MouseState IMouseDriver2.GetCursorState()
@@ -1042,9 +1045,13 @@ namespace osuTK.Platform.MacOS
             return new KeyboardState();
         }
 
-        public KeyboardState[] GetStates()
+        public void GetStates(List<KeyboardState> result)
         {
-            return KeyboardDevices.Select(device => device.State).ToArray();
+            result.Clear();
+            foreach (var device in KeyboardDevices)
+            {
+                result.Add(device.State);
+            }
         }
 
         string IKeyboardDriver2.GetDeviceName(int index)
@@ -1070,9 +1077,13 @@ namespace osuTK.Platform.MacOS
             return new JoystickState();
         }
 
-        JoystickState[] IJoystickDriver2.GetStates()
+        void IJoystickDriver2.GetStates(List<JoystickState> result)
         {
-            return JoystickDevices.Select(device => device.State).ToArray();
+            result.Clear();
+            foreach (var device in JoystickDevices)
+            {
+                result.Add(device.State);
+            }
         }
 
         JoystickCapabilities IJoystickDriver2.GetCapabilities(int index)

--- a/src/osuTK/Platform/SDL2/Sdl2JoystickDriver.cs
+++ b/src/osuTK/Platform/SDL2/Sdl2JoystickDriver.cs
@@ -26,7 +26,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using osuTK.Input;
 
 namespace osuTK.Platform.SDL2
@@ -629,9 +628,13 @@ namespace osuTK.Platform.SDL2
             return state;
         }
 
-        JoystickState[] IJoystickDriver2.GetStates()
+        void IJoystickDriver2.GetStates(List<JoystickState> result)
         {
-            return Enumerable.Range(0, joysticks.Count).Select(index => ((IJoystickDriver2)this).GetState(index)).ToArray();
+            result.Clear();
+            for (int i = 0; i < joysticks.Count; i++)
+            {
+                result.Add(((IJoystickDriver2)this).GetState(i));
+            }
         }
 
         JoystickCapabilities IJoystickDriver2.GetCapabilities(int index)

--- a/src/osuTK/Platform/SDL2/Sdl2Keyboard.cs
+++ b/src/osuTK/Platform/SDL2/Sdl2Keyboard.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System.Collections.Generic;
 using osuTK.Input;
 
 namespace osuTK.Platform.SDL2
@@ -93,9 +94,13 @@ namespace osuTK.Platform.SDL2
             }
         }
 
-        public KeyboardState[] GetStates()
+        public void GetStates(List<KeyboardState> result)
         {
-            return new[] {GetState(0)};
+            result.Clear();
+            for (int i = 0; i < 1; i++)
+            {
+                result.Add(((IKeyboardDriver2)this).GetState(i));
+            }
         }
 
         public string GetDeviceName(int index)

--- a/src/osuTK/Platform/SDL2/Sdl2Mouse.cs
+++ b/src/osuTK/Platform/SDL2/Sdl2Mouse.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using osuTK.Input;
 
@@ -117,9 +118,13 @@ namespace osuTK.Platform.SDL2
             }
         }
 
-        public MouseState[] GetStates()
+        public void GetStates(List<MouseState> result)
         {
-            return new[] { GetState(0) };
+            result.Clear();
+            for (int i = 0; i < 1; i++)
+            {
+                result.Add(((IMouseDriver2)this).GetState(i));
+            }
         }
 
         public MouseState GetCursorState()

--- a/src/osuTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/osuTK/Platform/Windows/WinRawJoystick.cs
@@ -28,7 +28,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using osuTK.Input;
 using osuTK.Platform.Common;
@@ -821,11 +820,15 @@ namespace osuTK.Platform.Windows
             }
         }
 
-        public JoystickState[] GetStates()
+        public void GetStates(List<JoystickState> result)
         {
             lock (UpdateLock)
             {
-                return Enumerable.Range(0, Devices.Count()).Select(GetState).ToArray();
+                result.Clear();
+                for (int i = 0; i < Devices.Count; i++)
+                {
+                    result.Add(GetState(i));
+                }
             }
         }
 

--- a/src/osuTK/Platform/Windows/WinRawKeyboard.cs
+++ b/src/osuTK/Platform/Windows/WinRawKeyboard.cs
@@ -290,11 +290,15 @@ namespace osuTK.Platform.Windows
             }
         }
 
-        public KeyboardState[] GetStates()
+        public void GetStates(List<KeyboardState> result)
         {
             lock (UpdateLock)
             {
-                return keyboards.ToArray();
+                result.Clear();
+                for (int i = 0; i < keyboards.Count; i++)
+                {
+                    result.Add(GetState(i));
+                }
             }
         }
 

--- a/src/osuTK/Platform/Windows/WinRawMouse.cs
+++ b/src/osuTK/Platform/Windows/WinRawMouse.cs
@@ -352,11 +352,15 @@ namespace osuTK.Platform.Windows
             }
         }
 
-        public MouseState[] GetStates()
+        public void GetStates(List<MouseState> result)
         {
             lock (UpdateLock)
             {
-                return mice.ToArray();
+                result.Clear();
+                for (int i = 0; i < mice.Count; i++)
+                {
+                    result.Add(GetState(i));
+                }
             }
         }
 

--- a/src/osuTK/Platform/Windows/XInputJoystick.cs
+++ b/src/osuTK/Platform/Windows/XInputJoystick.cs
@@ -26,6 +26,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using osuTK.Input;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -476,7 +477,7 @@ namespace osuTK.Platform.Windows
             }
         }
 
-        public JoystickState[] GetStates()
+        public void GetStates(List<JoystickState> result)
         {
             throw new NotImplementedException($"Use {nameof(WinRawJoystick)}'s {nameof(GetStates)} instead");
         }

--- a/src/osuTK/Platform/X11/X11Keyboard.cs
+++ b/src/osuTK/Platform/X11/X11Keyboard.cs
@@ -24,6 +24,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using osuTK.Input;
 
@@ -90,9 +91,13 @@ namespace osuTK.Platform.X11
             }
         }
 
-        public KeyboardState[] GetStates()
+        public void GetStates(List<KeyboardState> result)
         {
-            return new[] {GetState(0)};
+            result.Clear();
+            for (int i = 0; i < 1; i++)
+            {
+                result.Add(GetState(i));
+            }
         }
 
         public string GetDeviceName(int index)

--- a/src/osuTK/Platform/X11/X11Mouse.cs
+++ b/src/osuTK/Platform/X11/X11Mouse.cs
@@ -24,6 +24,7 @@
  //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using osuTK.Input;
 
@@ -82,9 +83,13 @@ namespace osuTK.Platform.X11
             }
         }
 
-        public MouseState[] GetStates()
+        public void GetStates(List<MouseState> result)
         {
-            return new[] { GetState(0) };
+            result.Clear();
+            for (int i = 0; i < 1; i++)
+            {
+                result.Add(GetState(i));
+            }
         }
 
         public MouseState GetCursorState()

--- a/src/osuTK/Platform/X11/XI2MouseKeyboard.cs
+++ b/src/osuTK/Platform/X11/XI2MouseKeyboard.cs
@@ -246,7 +246,7 @@ namespace osuTK.Platform.X11
             lock (Sync)
             {
                 result.Clear();
-                for (int i = 0; i < keyboards.Count; i++)
+                for (int i = 0; i < devices.Count; i++)
                 {
                     result.Add(((IMouseDriver2)this).GetState(i));
                 }

--- a/src/osuTK/Platform/X11/XI2MouseKeyboard.cs
+++ b/src/osuTK/Platform/X11/XI2MouseKeyboard.cs
@@ -26,7 +26,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using osuTK.Input;
@@ -193,11 +192,15 @@ namespace osuTK.Platform.X11
             }
         }
 
-        public KeyboardState[] GetStates()
+        public void GetStates(List<KeyboardState> result)
         {
             lock (Sync)
             {
-                return keyboards.Select(device => device.State).ToArray();
+                result.Clear();
+                for (int i = 0; i < keyboards.Count; i++)
+                {
+                    result.Add(((IKeyboardDriver2)this).GetState(i));
+                }
             }
         }
 
@@ -238,11 +241,15 @@ namespace osuTK.Platform.X11
             }
         }
 
-        MouseState[] IMouseDriver2.GetStates()
+        void IMouseDriver2.GetStates(List<MouseState> result)
         {
             lock (Sync)
             {
-                return devices.Select(d => d.State).ToArray();
+                result.Clear();
+                for (int i = 0; i < keyboards.Count; i++)
+                {
+                    result.Add(((IMouseDriver2)this).GetState(i));
+                }
             }
         }
 


### PR DESCRIPTION
As requested on ppy/osu-framework#1796.
This PR changes the signature from `JoystickState[] GetStates();` to `void GetStates(List<JoystickState> result);` to reuse allocation of the list. Ditto for the `Keyboard` and `Mouse` counterparts.