### PR TITLE
Android framebuffer

### DIFF
--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -160,6 +160,30 @@ namespace osuTK.Android
             base.Dispose (disposing);
         }
 
+        protected override void CreateFrameBuffer()
+        {
+            EnsureUndisposed();
+
+            int major = 0, minor = 0;
+            switch(ContextRenderingApi)
+            {
+                case GLVersion.ES1: major = 1; minor = 1; break;
+                case GLVersion.ES2: major = 2; minor = 0; break;
+                case GLVersion.ES3: major = 3; minor = 0; break;
+                default:
+                    throw new ArgumentException("Unsupported ContextRenderingApi version: " + ContextRenderingApi);
+            }
+
+            GraphicsMode = GraphicsMode.Default;
+            GraphicsContext = new GraphicsContext(GraphicsMode, WindowInfo, major, minor, GraphicsContextFlags.Embedded);
+            GraphicsContext.MakeCurrent(WindowInfo);
+            GraphicsContext.LoadAll();
+
+            gl = GLCalls.GetGLCalls(ContextRenderingApi);
+            if (renderOnUIThread)
+                MakeCurrent();
+        }
+
         protected virtual void DestroyFrameBuffer ()
         {
             // TODO: Somehow DestroySurface is being called twice (once by SurfaceDestroyed and once by UnloadInternal->DestroyFrameBuffer)
@@ -353,6 +377,7 @@ namespace osuTK.Android
                 GraphicsMode = GraphicsMode.Default;
 
             GraphicsContext = new GraphicsContext(GraphicsMode, WindowInfo, (int)ContextRenderingApi, 0, GraphicsContextFlags.Embedded);
+            GraphicsContext.LoadAll();
         }
 
         private void DestroyContext ()

--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -167,9 +167,18 @@ namespace osuTK.Android
             int major = 0, minor = 0;
             switch(ContextRenderingApi)
             {
-                case GLVersion.ES1: major = 1; minor = 1; break;
-                case GLVersion.ES2: major = 2; minor = 0; break;
-                case GLVersion.ES3: major = 3; minor = 0; break;
+                case GLVersion.ES1:
+                    major = 1;
+                    minor = 1;
+                    break;
+                case GLVersion.ES2:
+                    major = 2;
+                    minor = 0;
+                    break;
+                case GLVersion.ES3:
+                    major = 3;
+                    minor = 0;
+                    break;
                 default:
                     throw new ArgumentException("Unsupported ContextRenderingApi version: " + ContextRenderingApi);
             }

--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -377,7 +377,6 @@ namespace osuTK.Android
                 GraphicsMode = GraphicsMode.Default;
 
             GraphicsContext = new GraphicsContext(GraphicsMode, WindowInfo, (int)ContextRenderingApi, 0, GraphicsContextFlags.Embedded);
-            GraphicsContext.LoadAll();
         }
 
         private void DestroyContext ()

--- a/src/osuTK.Android/GameViewBase.cs
+++ b/src/osuTK.Android/GameViewBase.cs
@@ -1099,12 +1099,8 @@ namespace osuTK
         ///   </para>
         /// </remarks>
         public Rectangle ClientRectangle {
-            get {
-                throw new NotSupportedException ();
-            }
-            set {
-                throw new NotSupportedException ();
-            }
+            get => new Rectangle(0, 0, Width, Height);
+            set { }
         }
 
         /// <summary>This member is not supported.</summary>
@@ -1115,12 +1111,8 @@ namespace osuTK
         ///   </para>
         /// </remarks>
         public Size ClientSize {
-            get {
-                throw new NotSupportedException ();
-            }
-            set {
-                throw new NotSupportedException ();
-            }
+            get => new Size(Width, Height);
+            set { }
         }
 
         MouseCursor INativeWindow.Cursor

--- a/src/osuTK.Android/GameViewBase.cs
+++ b/src/osuTK.Android/GameViewBase.cs
@@ -1100,7 +1100,9 @@ namespace osuTK
         /// </remarks>
         public Rectangle ClientRectangle {
             get => new Rectangle(0, 0, Width, Height);
-            set { }
+            set {
+                throw new NotSupportedException();
+            }
         }
 
         /// <summary>This member is not supported.</summary>
@@ -1112,7 +1114,9 @@ namespace osuTK
         /// </remarks>
         public Size ClientSize {
             get => new Size(Width, Height);
-            set { }
+            set {
+                throw new NotSupportedException(); 
+            }
         }
 
         MouseCursor INativeWindow.Cursor


### PR DESCRIPTION
### Purpose of this PR

* Implements ClientSize, ClientRectangle, and overrides CreateFrameBuffer()
* Only affects Android.

### Testing status

* This is required for SampleGame.Android to work on osu-framework.
* Has been tested.

### Comments

* GL entry points are not loaded automatically. As such, they are manually loaded when a framebuffer is created. ClientSize and ClientRectangle are only supported because osu-framework mandates it.
