### PR TITLE
Remove exceptions from Android events

### DIFF
--- a/src/osuTK.Android/GameViewBase.cs
+++ b/src/osuTK.Android/GameViewBase.cs
@@ -1145,16 +1145,18 @@ namespace osuTK
             remove { throw new NotSupportedException(); }
         }
 
-        event EventHandler<KeyboardKeyEventArgs> INativeWindow.KeyDown
+        public event EventHandler<KeyboardKeyEventArgs> KeyDown;
+
+        public virtual void OnKeyDown(KeyboardKeyEventArgs args)
         {
-            add { throw new NotSupportedException(); }
-            remove { throw new NotSupportedException(); }
+            KeyDown?.Invoke(this, args);
         }
 
-        event EventHandler<KeyboardKeyEventArgs> INativeWindow.KeyUp
+        public event EventHandler<KeyboardKeyEventArgs> KeyUp;
+
+        public virtual void OnKeyUp(KeyboardKeyEventArgs args)
         {
-            add { throw new NotSupportedException(); }
-            remove { throw new NotSupportedException(); }
+            KeyUp?.Invoke(this, args);
         }
 
         event EventHandler<MouseButtonEventArgs> INativeWindow.MouseDown

--- a/src/osuTK.Android/GameViewBase.cs
+++ b/src/osuTK.Android/GameViewBase.cs
@@ -850,10 +850,7 @@ namespace osuTK
         ///     Throws a <see cref="T:System.NotSupportedException" />.
         ///   </para>
         /// </remarks>
-        public event EventHandler<EventArgs> MouseEnter {
-            add { throw new NotSupportedException (); }
-            remove { throw new NotSupportedException (); }
-        }
+        public event EventHandler<EventArgs> MouseEnter;
 
         /// <summary>This member is not supported.</summary>
         /// <remarks>
@@ -861,10 +858,7 @@ namespace osuTK
         ///     Throws a <see cref="T:System.NotSupportedException" />.
         ///   </para>
         /// </remarks>
-        public event EventHandler<EventArgs> MouseLeave {
-            add { throw new NotSupportedException (); }
-            remove { throw new NotSupportedException (); }
-        }
+        public event EventHandler<EventArgs> MouseLeave;
 
         /// <summary>This member is not supported.</summary>
         /// <remarks>
@@ -1147,17 +1141,7 @@ namespace osuTK
 
         public event EventHandler<KeyboardKeyEventArgs> KeyDown;
 
-        public virtual void OnKeyDown(KeyboardKeyEventArgs args)
-        {
-            KeyDown?.Invoke(this, args);
-        }
-
         public event EventHandler<KeyboardKeyEventArgs> KeyUp;
-
-        public virtual void OnKeyUp(KeyboardKeyEventArgs args)
-        {
-            KeyUp?.Invoke(this, args);
-        }
 
         event EventHandler<MouseButtonEventArgs> INativeWindow.MouseDown
         {

--- a/src/osuTK.Android/GameViewBase.cs
+++ b/src/osuTK.Android/GameViewBase.cs
@@ -1121,14 +1121,14 @@ namespace osuTK
 
         MouseCursor INativeWindow.Cursor
         {
-            get { throw new NotSupportedException(); }
-            set { throw new NotSupportedException(); }
+            get;
+            set;
         }
 
         bool INativeWindow.CursorVisible
         {
-            get { throw new NotSupportedException(); }
-            set { throw new NotSupportedException(); }
+            get;
+            set;
         }
 
         Icon INativeWindow.Icon


### PR DESCRIPTION
### Purpose of this PR

* Removes throwing exceptions from events used by [osu-framework](https://github.com/ppy/osu-framework) on Android.
* Only affects osuTK.Android.

### Testing status

* Conducted on [osu-framework](https://github.com/ppy/osu-framework) tests on Android ([#2021](https://github.com/ppyosu-framework/pull/2021)). No errors found during runtime.

### Notes

* This PR is so I can remove the conditions added to `GameWindow` for events that Android had thrown an exception on previously.