### PR TITLE
Remove Render from run thread as it is not required

### DIFF
--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -545,15 +545,6 @@ namespace osuTK.Android
 
             UpdateFrameInternal (updateEventArgs);
             prevUpdateTime = curUpdateTime;
-
-            curRenderTime = DateTime.Now;
-            if (prevRenderTime.Ticks == 0) {
-                var t = (curRenderTime - prevRenderTime).TotalSeconds;
-                renderEventArgs.Time = t;
-            }
-
-            RenderFrameInternal (renderEventArgs);
-            prevRenderTime = curRenderTime;
         }
 
         partial void log (string msg);


### PR DESCRIPTION
### Purpose of this PR

Removes the Render Frame calls, as these are handled in the framework - but the Focused/isActive binding happens in the initial Update Frame call. This will keep the Update Frame calls happening when needed for the Open TK things

### Testing status

This is still a WIP - as I have not tried yet with the main game - but should be fine and seems to be OK with the Sample Android game. 

Side effect seems to be a DLL exception for bass when running on emulator on Windows - but looking at logs this was still happening before these calls? Need to investigate more.
