### PR TITLE
Re-enable event tap if disabled

### DIFF
--- a/src/osuTK/Platform/MacOS/HIDInput.cs
+++ b/src/osuTK/Platform/MacOS/HIDInput.cs
@@ -297,6 +297,13 @@ namespace osuTK.Platform.MacOS
                             CursorState[b] = false;
                         }
                         break;
+                    
+                    case CGEventType.TapDisabledByTimeout:
+                    case CGEventType.TapDisabledByUserInput:
+                    {
+                        CG.EventTapEnable(MouseEventTap, true);
+                    }
+                        break;
                 }
             }
             catch (Exception e)

--- a/src/osuTK/Platform/MacOS/HIDInput.cs
+++ b/src/osuTK/Platform/MacOS/HIDInput.cs
@@ -300,9 +300,9 @@ namespace osuTK.Platform.MacOS
                     
                     case CGEventType.TapDisabledByTimeout:
                     case CGEventType.TapDisabledByUserInput:
-                    {
-                        CG.EventTapEnable(MouseEventTap, true);
-                    }
+                        {
+                            CG.EventTapEnable(MouseEventTap, true);
+                        }
                         break;
                 }
             }

--- a/src/osuTK/Platform/MacOS/Quartz/EventServices.cs
+++ b/src/osuTK/Platform/MacOS/Quartz/EventServices.cs
@@ -52,6 +52,9 @@ namespace osuTK.Platform.MacOS
             [MarshalAs(UnmanagedType.FunctionPtr)]
             EventTapCallBack callback,
             IntPtr refcon);
+        
+        [DllImport(lib, EntryPoint = "CGEventTapEnable")]
+        internal static extern CFMachPortRef EventTapEnable(CFMachPortRef tap, bool enable);
 
         [DllImport(lib, EntryPoint = "CGEventGetDoubleValueField")]
         internal static extern double EventGetDoubleValueField(


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/2167

Previously, losing focus of the window would fire `TapDisabledByUserInput` on exactly the third time we lose focus of the window.

This will permanently disable the event tap, making it impossible to update our cursor position afterwards.

Unfortunately, [apple documentation](https://developer.apple.com/documentation/coregraphics/cgeventtype/tapdisabledbyuserinput) and google searching reveals nothing about this behavior. However, some google searching leads me to believe that a common hack is to simply [re-enable the event tap](https://gist.github.com/avaidyam/0892bf9fd86cb1c49349ebecfc2b5c80#file-indirectswiperecognizer-swift-L62) [if its disabled](https://github.com/tekezo/AXAlert/blob/master/AXAlert/Classes/KeyboardEventLeaker.m), or [run enable](https://gist.github.com/osnr/23eb05b4e0bcd335c06361c4fabadd6f)[ in a run loop](https://gist.github.com/cprovatas/6acef442fc43123bcd5d5e937dc7951a).

I've made it so the tap gets re-enabled every time it gets disabled for now, but hopefully someone more familiar can provide more clarification if possible.
