### PR TITLE
Attempt to fix window background-ness

### DIFF
--- a/src/osuTK/Platform/MacOS/Cocoa/NSApplication.cs
+++ b/src/osuTK/Platform/MacOS/Cocoa/NSApplication.cs
@@ -43,6 +43,36 @@ namespace osuTK.Platform.MacOS
             System.Threading.Thread.CurrentThread.ManagedThreadId;
 
         internal static void Initialize() { }
+        
+        [DllImport ("/System/Library/Frameworks/AppKit.framework/AppKit")]
+        internal static extern int TransformProcessType(ref ProcessSerialNumber psn, ProcessApplicationTransformState type);
+        
+        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static extern int GetCurrentProcess(ref ProcessSerialNumber psn);
+        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static extern int SetFrontProcess(ref ProcessSerialNumber psn);
+        
+        internal struct ProcessSerialNumber
+        {
+            public ulong high;
+            public ulong low;
+        }
+        
+        private static void TransformProcessToForeground()
+        {
+            ProcessSerialNumber psn = new ProcessSerialNumber();
+            
+            Debug.Print("Setting process to be foreground application.");
+            
+            GetCurrentProcess(ref psn);
+            TransformProcessType(ref psn, ProcessApplicationTransformState.kProcessTransformToForegroundApplication);
+            SetFrontProcess(ref psn);
+        }
+        
+        internal enum ProcessApplicationTransformState : int
+        {
+            kProcessTransformToForegroundApplication = 1,
+        }
 
         static NSApplication()
         {
@@ -101,6 +131,8 @@ namespace osuTK.Platform.MacOS
                 Selector.Get("registerDefaults:"),
                 settings);
             Cocoa.SendVoid(settings, Selector.Release);
+
+            TransformProcessToForeground();
         }
 
         internal static bool IsUIThread


### PR DESCRIPTION
attempt to fix window not becoming a real window in macOS (i believe it is set to `background` internally). Note that this is only applicable to the case the application is not in a bundle with an info.plist.

https://github.com/mono/cocoa-sharp/blob/master/src/Cocoa/Application.cs