### PR TITLE
Increase joystick button limit & prevent ghost press-release events from firing

### DIFF
--- a/src/osuTK/Input/JoystickState.cs
+++ b/src/osuTK/Input/JoystickState.cs
@@ -141,7 +141,7 @@ namespace osuTK.Input
                 unsafe
                 {
                     for (int i = 0; i < MaxButtons; i++)
-                        if (buttons[i])
+                        if (IsButtonDown(i))
                             return true;
                 }
 
@@ -173,7 +173,7 @@ namespace osuTK.Input
             {
                 for (int i = 0; i < MaxButtons; i++)
                 {
-                    sbAxes.Append(buttons[i] ? "1" : "0");
+                    sbAxes.Append(IsButtonDown(i) ? "1" : "0");
                 }
             }
 
@@ -256,7 +256,7 @@ namespace osuTK.Input
             unsafe
             {
                 for (int i = 0; i < MaxButtons; i++)
-                    buttons[i] = false;
+                    SetButton(i, false);
             }
         }
 

--- a/src/osuTK/Input/JoystickState.cs
+++ b/src/osuTK/Input/JoystickState.cs
@@ -72,11 +72,8 @@ namespace osuTK.Input
         /// <returns><see cref="ButtonState.Pressed"/> if the specified button is pressed; otherwise, <see cref="ButtonState.Released"/>.</returns>
         /// <param name="button">The button to query.</param>
         public ButtonState GetButton(int button)
-        {
-            unsafe
-            {
-                return buttons[button] ? ButtonState.Pressed : ButtonState.Released;
-            }
+        { 
+            return IsButtonDown(button) ? ButtonState.Pressed : ButtonState.Released;
         }
 
         /// <summary>
@@ -108,9 +105,18 @@ namespace osuTK.Input
         /// <param name="button">The button to query.</param>
         public bool IsButtonDown(int button)
         {
+            if (button < 0 || button >= MaxButtons)
+            {
+                Debug.Print("[Joystick] IsButtonDown on invalid button {0}", button);
+                return false;
+            }
+
             unsafe
             {
-                return buttons[button];
+                fixed (bool* pbuttons = buttons)
+                {
+                    return *(pbuttons + button);
+                }
             }
         }
 
@@ -121,10 +127,7 @@ namespace osuTK.Input
         /// <param name="button">The button to query.</param>
         public bool IsButtonUp(int button)
         {
-            unsafe
-            {
-                return !buttons[button];
-            }
+            return !IsButtonDown(button);
         }
 
         /// <summary>
@@ -225,7 +228,7 @@ namespace osuTK.Input
             }
             else
             {
-                Debug.Print("[Joystick] Invalid axis {0}", axis);
+                Debug.Print("[Joystick] GetAxisRaw on invalid axis {0}", axis);
             }
             return value;
         }
@@ -235,7 +238,8 @@ namespace osuTK.Input
             int index = axis;
             if (index < 0 || index >= MaxAxes)
             {
-                throw new ArgumentOutOfRangeException("axis");
+                Debug.Print("[Joystick] Attempted SetAxis on invalid axis {0}", axis);
+                return;
             }
 
             unsafe
@@ -260,12 +264,16 @@ namespace osuTK.Input
         {
             if (button < 0 || button >= MaxButtons)
             {
-                throw new ArgumentOutOfRangeException("button");
+                Debug.Print("[Joystick] SetButton on invalid button {0}", button);
+                return;
             }
 
             unsafe
             {
-                buttons[button] = value;
+                fixed (bool* pbuttons = buttons)
+                {
+                    *(pbuttons + button) = value;
+                }
             }
         }
 

--- a/src/osuTK/Input/JoystickState.cs
+++ b/src/osuTK/Input/JoystickState.cs
@@ -26,6 +26,7 @@
 //
 
 using System;
+using System.Collections;
 using System.Diagnostics;
 using System.Text;
 
@@ -39,12 +40,12 @@ namespace osuTK.Input
         // If we ever add more values to JoystickAxis or JoystickButton
         // then we'll need to increase these limits.
         internal const int MaxAxes = 64;
-        internal const int MaxButtons = 64;
+        internal const int MaxButtons = 128;
         internal const int MaxHats = (int)JoystickHat.Last + 1;
 
         private const float ConversionFactor = 1.0f / (short.MaxValue + 0.5f);
 
-        private long buttons;
+        private unsafe fixed bool buttons[MaxButtons];
         private unsafe fixed short axes[MaxAxes];
         private JoystickHatState hat0;
         private JoystickHatState hat1;
@@ -72,7 +73,10 @@ namespace osuTK.Input
         /// <param name="button">The button to query.</param>
         public ButtonState GetButton(int button)
         {
-            return (buttons & ((long)1 << button)) != 0 ? ButtonState.Pressed : ButtonState.Released;
+            unsafe
+            {
+                return buttons[button] ? ButtonState.Pressed : ButtonState.Released;
+            }
         }
 
         /// <summary>
@@ -104,7 +108,10 @@ namespace osuTK.Input
         /// <param name="button">The button to query.</param>
         public bool IsButtonDown(int button)
         {
-            return (buttons & ((long)1 << button)) != 0;
+            unsafe
+            {
+                return buttons[button];
+            }
         }
 
         /// <summary>
@@ -114,7 +121,10 @@ namespace osuTK.Input
         /// <param name="button">The button to query.</param>
         public bool IsButtonUp(int button)
         {
-            return (buttons & ((long)1 << button)) == 0;
+            unsafe
+            {
+                return !buttons[button];
+            }
         }
 
         /// <summary>
@@ -125,8 +135,14 @@ namespace osuTK.Input
         {
             get
             {
-                // If any bit is set then a button is down.
-                return buttons != 0;
+                unsafe
+                {
+                    for (int i = 0; i < MaxButtons; i++)
+                        if (buttons[i])
+                            return true;
+                }
+
+                return false;
             }
         }
 
@@ -142,16 +158,26 @@ namespace osuTK.Input
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="osuTK.Input.JoystickState"/>.</returns>
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sbAxes = new StringBuilder();
             for (int i = 0; i < MaxAxes; i++)
             {
-                sb.Append(" ");
-                sb.Append(String.Format("{0:f4}", GetAxis(i)));
+                sbAxes.Append(" ");
+                sbAxes.Append(String.Format("{0:f4}", GetAxis(i)));
             }
+            
+            StringBuilder sbBtns = new StringBuilder();
+            unsafe
+            {
+                for (int i = 0; i < MaxButtons; i++)
+                {
+                    sbAxes.Append(buttons[i] ? "1" : "0");
+                }
+            }
+
             return String.Format(
                 "{{Axes:{0}; Buttons: {1}; Hat: {2}; IsConnected: {3}}}",
-                sb.ToString(),
-                Convert.ToString(buttons, 2).PadLeft(16, '0'),
+                sbAxes,
+                sbBtns,
                 hat0,
                 IsConnected);
         }
@@ -163,7 +189,11 @@ namespace osuTK.Input
         /// hash table.</returns>
         public override int GetHashCode()
         {
-            int hash = buttons.GetHashCode() ^ IsConnected.GetHashCode();
+            int hash = IsConnected.GetHashCode();
+            for (int i = 0; i < MaxButtons; i++)
+            {
+                hash ^= IsButtonDown(i).GetHashCode();
+            }
             for (int i = 0; i < MaxAxes; i++)
             {
                 hash ^= GetAxisUnsafe(i).GetHashCode();
@@ -205,7 +235,7 @@ namespace osuTK.Input
             int index = axis;
             if (index < 0 || index >= MaxAxes)
             {
-                return;
+                throw new ArgumentOutOfRangeException("axis");
             }
 
             unsafe
@@ -219,23 +249,23 @@ namespace osuTK.Input
 
         internal void ClearButtons()
         {
-            buttons = 0;
+            unsafe
+            {
+                for (int i = 0; i < MaxButtons; i++)
+                    buttons[i] = false;
+            }
         }
 
         internal void SetButton(int button, bool value)
         {
             if (button < 0 || button >= MaxButtons)
             {
-                return;
+                throw new ArgumentOutOfRangeException("button");
             }
 
-            if (value)
+            unsafe
             {
-                buttons |= (long)1 << button;
-            }
-            else
-            {
-                buttons &= ~((long)1 << button);
+                buttons[button] = value;
             }
         }
 
@@ -289,9 +319,11 @@ namespace osuTK.Input
         /// <see cref="osuTK.Input.JoystickState"/>; otherwise, <c>false</c>.</returns>
         public bool Equals(JoystickState other)
         {
-            bool equals =
-                buttons == other.buttons &&
-                IsConnected == other.IsConnected;
+            bool equals = IsConnected == other.IsConnected;
+            for (int i = 0; equals && i < MaxButtons; i++)
+            {
+                equals &= IsButtonDown(i) == other.IsButtonDown(i);
+            }
             for (int i = 0; equals && i < MaxAxes; i++)
             {
                 equals &= GetAxisUnsafe(i) == other.GetAxisUnsafe(i);

--- a/src/osuTK/Input/JoystickState.cs
+++ b/src/osuTK/Input/JoystickState.cs
@@ -138,12 +138,9 @@ namespace osuTK.Input
         {
             get
             {
-                unsafe
-                {
-                    for (int i = 0; i < MaxButtons; i++)
-                        if (IsButtonDown(i))
-                            return true;
-                }
+                for (int i = 0; i < MaxButtons; i++)
+                    if (IsButtonDown(i))
+                        return true;
 
                 return false;
             }
@@ -253,11 +250,8 @@ namespace osuTK.Input
 
         internal void ClearButtons()
         {
-            unsafe
-            {
-                for (int i = 0; i < MaxButtons; i++)
-                    SetButton(i, false);
-            }
+            for (int i = 0; i < MaxButtons; i++)
+                SetButton(i, false);
         }
 
         internal void SetButton(int button, bool value)

--- a/src/osuTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/osuTK/Platform/Windows/WinRawJoystick.cs
@@ -452,8 +452,8 @@ namespace osuTK.Platform.Windows
 
             for (int i = 0; i < stick.ButtonCaps.Count; i++)
             {
-                short* usage_list = stackalloc short[64];
-                int usage_length = 64;
+                short* usage_list = stackalloc short[128];
+                int usage_length = 128;
                 HIDPage page = stick.ButtonCaps[i].UsagePage;
                 short collection = stick.ButtonCaps[i].LinkCollection;
 

--- a/src/osuTK/Platform/Windows/WinRawJoystick.cs
+++ b/src/osuTK/Platform/Windows/WinRawJoystick.cs
@@ -336,8 +336,11 @@ namespace osuTK.Platform.Windows
                         Array.Resize(ref DataBuffer, report_count);
                     }
 
-                    UpdateAxes(rin, stick);
-                    UpdateButtons(rin, stick);
+                    lock (stick)
+                    {
+                        UpdateAxes(rin, stick);
+                        UpdateButtons(rin, stick);
+                    }
                     return true;
                 }
             }
@@ -813,7 +816,10 @@ namespace osuTK.Platform.Windows
                     }
                     else
                     {
-                        return dev.GetState();
+                        lock (dev)
+                        {
+                            return dev.GetState();
+                        }
                     }
                 }
                 return new JoystickState();


### PR DESCRIPTION
Lifts the joystick button limit of 64 by using a fixed bool array instead of bit masked qword
The fixed array performs marginally faster with a memory footprint increase of 112 bytes per device.

Also fixes a race condition which can cause held buttons to trigger extra release and press events while being held.

### Testing status

* Tested on Windows using Osu!

### Comments

* Linux and OS X specific code seemed to not have the 64 limit to begin with.