### PR TITLE
Remove explicit .dylib from libdl name

### DIFF
--- a/src/osuTK/Platform/MacOS/NS.cs
+++ b/src/osuTK/Platform/MacOS/NS.cs
@@ -49,7 +49,7 @@ namespace osuTK.Platform.MacOS
 
     public class NS
     {
-        private const string Library = "libdl.dylib";
+        private const string Library = "libdl";
 
         [DllImport(Library, EntryPoint = "NSAddImage")]
         internal static extern IntPtr AddImage(string s, AddImageFlags flags);


### PR DESCRIPTION
Attempts to `fix` https://github.com/ppy/osu/issues/7791

Note that there's another libdl.dylib https://github.com/ppy/osu-framework/blob/master/osu.Framework/Platform/MacOS/Native/Cocoa.cs#L11, but given that the previous stacktrace occurred at this point, this change is enough to determine if there's any possible improvement.