### PR TITLE
Replace iOS CADisplayLink deprecated frame interval API with preferred FPS

### DIFF
--- a/src/osuTK.iOS/iOSGameView.cs
+++ b/src/osuTK.iOS/iOSGameView.cs
@@ -743,7 +743,7 @@ namespace osuTK.iOS
             }
 
             if (updatesPerSecond == 0.0) {
-                RunWithFrameInterval (1);
+                RunWithPreferredFramesPerSecond (0);
                 return;
             }
 
@@ -759,7 +759,7 @@ namespace osuTK.iOS
             Start ();
         }
 
-        [Obsolete ("Use either Run (float updatesPerSecond) or RunWithFrameInterval (int frameInterval)")]
+        [Obsolete ("Use either Run (float updatesPerSecond) or RunWithPreferredFramesPerSecond(int preferredFramesPerSecond)")]
         public void Run(int preferredFramesPerSecond)
         {
             RunWithPreferredFramesPerSecond(preferredFramesPerSecond);

--- a/src/osuTK.iOS/iOSGameView.cs
+++ b/src/osuTK.iOS/iOSGameView.cs
@@ -140,7 +140,7 @@ namespace osuTK.iOS
         private iOSGameView view;
         private CADisplayLink displayLink;
 
-        public CADisplayLinkTimeSource (iOSGameView view, int frameInterval)
+        public CADisplayLinkTimeSource (iOSGameView view, int preferredFramesPerSecond)
         {
             this.view = view;
 
@@ -150,7 +150,7 @@ namespace osuTK.iOS
             }
 
             displayLink = CADisplayLink.Create (this, selRunIteration);
-            displayLink.FrameInterval = frameInterval;
+            displayLink.PreferredFramesPerSecond = preferredFramesPerSecond;
             displayLink.Paused = true;
         }
 
@@ -732,7 +732,7 @@ namespace osuTK.iOS
 
         public void Run()
         {
-            RunWithFrameInterval (1);
+            RunWithPreferredFramesPerSecond(0);
         }
 
         public void Run(double updatesPerSecond)
@@ -760,18 +760,18 @@ namespace osuTK.iOS
         }
 
         [Obsolete ("Use either Run (float updatesPerSecond) or RunWithFrameInterval (int frameInterval)")]
-        public void Run(int frameInterval)
+        public void Run(int preferredFramesPerSecond)
         {
-            RunWithFrameInterval (frameInterval);
+            RunWithPreferredFramesPerSecond(preferredFramesPerSecond);
         }
 
-        public void RunWithFrameInterval(int frameInterval)
+        public void RunWithPreferredFramesPerSecond(int preferredFramesPerSecond)
         {
             AssertValid ();
 
-            if (frameInterval < 1)
+            if (preferredFramesPerSecond < 0)
             {
-                throw new ArgumentException ("frameInterval");
+                throw new ArgumentException ("preferredFramesPerSecond");
             }
 
             if (timesource != null)
@@ -779,7 +779,7 @@ namespace osuTK.iOS
                 timesource.Invalidate ();
             }
 
-            timesource = new CADisplayLinkTimeSource (this, frameInterval);
+            timesource = new CADisplayLinkTimeSource (this, preferredFramesPerSecond);
 
             CreateFrameBuffer ();
             OnLoad (EventArgs.Empty);


### PR DESCRIPTION
### Purpose of this PR

In working with getting the iOS version of osu!lazer working more efficiently on a single thread, it was noted that the input framerate was getting capped at 60FPS on iOS devices with higher frame rates, like iPad Pro.

On examining the refresh timer implementation in osuTK, it was discovered that the `CADisplayLink` timer was being configured with an API that was deprecated at the same time the high FPS APIs were introduced.

This PR replaces the frame interval configuration with the newer `preferredFramesPerSecond`, and then implements the default state of deferring to the reported FPS limit of the display screen in question.

### Testing status

It was manually tested by building a local NuGet package of iOS osuTK, installing that into a local install of osu-framework, and then testing various FPS caps. By setting various test FPS caps, it was confirmed that the `CADisplayLink` was being configured correctly by these changes.

- Closes https://github.com/ppy/osu/issues/8008