### PR TITLE
Fix initial window focus on macOS versions prior to Catalina

### DIFF
--- a/src/osuTK/Platform/MacOS/Cocoa/Cocoa.cs
+++ b/src/osuTK/Platform/MacOS/Cocoa/Cocoa.cs
@@ -89,6 +89,9 @@ namespace osuTK.Platform.MacOS
 
         [DllImport(LibObjC, EntryPoint="objc_msgSend")]
         public extern static bool SendBool(IntPtr receiver, IntPtr selector, int int1);
+        
+        [DllImport(LibObjC, EntryPoint="objc_msgSend")]
+        public extern static bool SendBool(IntPtr receiver, IntPtr selector, NSOperatingSystemVersion version);
 
         [DllImport(LibObjC, EntryPoint="objc_msgSend")]
         public extern static void SendVoid(IntPtr receiver, IntPtr selector);

--- a/src/osuTK/Platform/MacOS/Cocoa/NSApplication.cs
+++ b/src/osuTK/Platform/MacOS/Cocoa/NSApplication.cs
@@ -57,6 +57,11 @@ namespace osuTK.Platform.MacOS
 
             // Setup the application
             Cocoa.SendBool(Handle, Selector.Get("setActivationPolicy:"), (int)NSApplicationActivationPolicy.Regular);
+            
+            // Versions of macOS prior to Catalina (10.15) must discard events here to ensure the app correctly gains focus
+            if (!NSProcessInfo.IsOperatingSystemAtLeastVersion(new NSOperatingSystemVersion(10, 15, 0)))
+                Cocoa.SendVoid(Handle, Selector.Get("discardEventsMatchingMask:beforeEvent:"), uint.MaxValue, IntPtr.Zero);
+            
             Cocoa.SendVoid(Handle, Selector.Get("activateIgnoringOtherApps:"), true);
 
             if (Cocoa.SendIntPtr(Handle, Selector.Get("mainMenu")) == IntPtr.Zero)

--- a/src/osuTK/Platform/MacOS/Cocoa/NSOperatingSystemVersion.cs
+++ b/src/osuTK/Platform/MacOS/Cocoa/NSOperatingSystemVersion.cs
@@ -1,0 +1,19 @@
+using System.Runtime.InteropServices;
+
+namespace osuTK.Platform.MacOS
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct NSOperatingSystemVersion
+    {
+        public long MajorVersion;
+        public long MinorVersion;
+        public long PatchVersion;
+        
+        public NSOperatingSystemVersion(long majorVersion, long minorVersion, long patchVersion)
+        {
+            MajorVersion = majorVersion;
+            MinorVersion = minorVersion;
+            PatchVersion = patchVersion;
+        }
+    }
+}

--- a/src/osuTK/Platform/MacOS/Cocoa/NSProcessInfo.cs
+++ b/src/osuTK/Platform/MacOS/Cocoa/NSProcessInfo.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace osuTK.Platform.MacOS
+{
+    internal static class NSProcessInfo
+    {
+        private static readonly IntPtr classProcessInfo = Class.Get("NSProcessInfo");
+        private static readonly IntPtr selProcessInfo = Selector.Get("processInfo");
+        private static readonly IntPtr selIsOperatingSystemAtLeastVersion = Selector.Get("isOperatingSystemAtLeastVersion:");
+
+        public static bool IsOperatingSystemAtLeastVersion(NSOperatingSystemVersion version)
+        {
+            var processInfo = Cocoa.SendIntPtr(classProcessInfo, selProcessInfo);
+            return Cocoa.SendBool(processInfo, selIsOperatingSystemAtLeastVersion, version);
+        }
+    }
+}


### PR DESCRIPTION
PR #57 fixed initial window focus on Catalina, but regressed on Mojave and prior.

This change uses `[NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:]` to restore the previous fix for versions prior to Catalina (10.15).

Tested on both Mojave and Catalina systems.