### PR TITLE
Fix mouse confinement being toggled on click

### DIFF
--- a/src/osuTK/Platform/SDL2/Sdl2.cs
+++ b/src/osuTK/Platform/SDL2/Sdl2.cs
@@ -459,6 +459,10 @@ namespace osuTK.Platform.SDL2
         public static extern void SetWindowGrab(IntPtr window, bool grabbed);
 
         [SuppressUnmanagedCodeSecurity]
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_CaptureMouse", ExactSpelling = true)]
+        public static extern void CaptureMouse(bool enabled);
+
+        [SuppressUnmanagedCodeSecurity]
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_SetWindowIcon", ExactSpelling = true)]
         public static extern void SetWindowIcon(IntPtr window, IntPtr icon);
 

--- a/src/osuTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/src/osuTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -223,11 +223,10 @@ namespace osuTK.Platform.SDL2
             bool button_pressed = ev.State == State.Pressed;
 
             // We need MouseUp events to be reported even if they occur
-            // outside the window. SetWindowGrab ensures we get them.
+            // outside the window. CaptureMouse ensures we get them.
             if (!window.is_cursor_grabbed)
             {
-                SDL.SetWindowGrab(window.window.Handle,
-                    button_pressed ? true : false);
+                SDL.CaptureMouse(button_pressed);
             }
 
             MouseButton button = Sdl2Mouse.TranslateButton(ev.Button);


### PR DESCRIPTION
This commit makes it so that [`SDL_CaptureMouse`](https://wiki.libsdl.org/SDL_CaptureMouse) is used instead of
[`SDL_SetGrabWindow`](https://wiki.libsdl.org/SDL_SetGrabWindow) to capture mouse up events that occur outside the SDL
window.

The existing comment makes it clear that this is what the original
developers intended, but the pre-existing code actually performs "don't
let the mouse cursor leave the window until it is released".

This fixes https://github.com/ppy/osu-framework/issues/3460.