### PR TITLE
Fix crashes on window resize/move on Windows with retry workaround

### DIFF
--- a/src/osuTK/Platform/Windows/WinGLContext.cs
+++ b/src/osuTK/Platform/Windows/WinGLContext.cs
@@ -297,7 +297,7 @@ namespace osuTK.Platform.Windows
         {
             bool success = false;
 
-            for (int retry = 0; retry < 5 && !success; retry++)
+            for (int retry = 0; retry < 10 && !success; retry++)
             {
                 success = Wgl.MakeCurrent(window.DeviceContext, contextHandle);
                 if (!success)

--- a/src/osuTK/Platform/Windows/WinGLContext.cs
+++ b/src/osuTK/Platform/Windows/WinGLContext.cs
@@ -56,21 +56,7 @@ namespace osuTK.Platform.Windows
                 Context = new ContextHandle(Wgl.CreateContext(window.DeviceContext));
                 if (Context != ContextHandle.Zero)
                 {
-                    // Make the context current.
-                    // Note: on some video cards and on some virtual machines, wglMakeCurrent
-                    // may fail with an errorcode of 6 (INVALID_HANDLE). The suggested workaround
-                    // is to call wglMakeCurrent in a loop until it succeeds.
-                    // See https://www.opengl.org/discussion_boards/showthread.php/171058-nVidia-wglMakeCurrent()-multiple-threads
-                    // Sigh...
-                    for (int retry = 0; retry < 5 && !success; retry++)
-                    {
-                        success = Wgl.MakeCurrent(window.DeviceContext, Context.Handle);
-                        if (!success)
-                        {
-                            Debug.Print("wglMakeCurrent failed with error: {0}. Retrying", Marshal.GetLastWin32Error());
-                            System.Threading.Thread.Sleep(10);
-                        }
-                    }
+                    success = TryMakeCurrent(window, Context.Handle);
                 }
                 else
                 {
@@ -279,7 +265,7 @@ namespace osuTK.Platform.Windows
                         throw new ArgumentException("window", "Must point to a valid window.");
                     }
 
-                    success = Wgl.MakeCurrent(wnd.DeviceContext, Handle.Handle);
+                    success = TryMakeCurrent(wnd, Handle.Handle);
                     DeviceContext = wnd.DeviceContext;
                 }
                 else
@@ -294,6 +280,34 @@ namespace osuTK.Platform.Windows
                         "Failed to make context {0} current. Error: {1}", this, Marshal.GetLastWin32Error()));
                 }
             }
+        }
+
+        /// <summary>
+        /// Tries to make the context current over several attempts.
+        /// </summary>
+        /// <remarks>
+        /// On some video cards and on some virtual machines, wglMakeCurrent
+        /// may fail with an error code of 6 (INVALID_HANDLE). The suggested workaround
+        /// is to call wglMakeCurrent in a loop until it succeeds.
+        /// See https://www.opengl.org/discussion_boards/showthread.php/171058-nVidia-wglMakeCurrent()-multiple-threads
+        /// In a majority of cases this will succeed on the first try.
+        /// </remarks>
+        /// <returns>Whether the context was successfully made current.</returns>
+        private static bool TryMakeCurrent(WinWindowInfo window, IntPtr contextHandle)
+        {
+            bool success = false;
+
+            for (int retry = 0; retry < 5 && !success; retry++)
+            {
+                success = Wgl.MakeCurrent(window.DeviceContext, contextHandle);
+                if (!success)
+                {
+                    Debug.Print("wglMakeCurrent failed with error: {0}. Retrying", Marshal.GetLastWin32Error());
+                    System.Threading.Thread.Sleep(10);
+                }
+            }
+
+            return success;
         }
 
         public override bool IsCurrent


### PR DESCRIPTION
Resolves crashes on Windows caused by resizing or moving the window that surfaced post-merge of ppy/osu-framework#3721.

# Summary

As noted on Discord, resizing the window on Windows (particularly to a size smaller than the minimum allowed, as I found) could cause crashes due to an `WglMakeCurrent` call failing. Curiously enough, that same call would then succeed moments later without any intervention on my part, or without having any other GL calls in between:

![image](https://user-images.githubusercontent.com/20418176/88093307-1ec34980-cb92-11ea-95a8-6afc6d02a50c.png)

so the game could *technically* keep running, if it hadn't eaten a managed exception from osuTK itself.

As seen in this diff osuTK already had a path for something precisely of this nature which tried to make the context current in a loop. This change extracts that code to a function and calls it at `MakeCurrent()` instead of trying once and failing.

# Remarks

As mentioned on Discord I had it crash once with 5 retries, but I think it was due to me experimenting with removing the sleep as I hate those sorts of solutions, but unfortunately it seems that this one will have to stay as not to spend too much time on fixing osuTK which is mostly on borrowed time anyway. I bumped it up to 10 for safety.

Tested manually by continually resizing the window for 60 seconds over 3 tries.