### PR TITLE
Speculative fix for android update crashes

### DIFF
--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -523,6 +523,8 @@ namespace osuTK.Android
         }
 
         private Stopwatch watchUpdate = new Stopwatch();
+        private long lastElapsedMilliseconds;
+
         private FrameEventArgs updateEventArgs = new FrameEventArgs();
 
         // this method is called on the main thread if RenderOnUIThread is true
@@ -534,11 +536,12 @@ namespace osuTK.Android
             if (!ReadyToRender)
                 return;
 
-            if (watchUpdate.ElapsedTicks != 0)
-                updateEventArgs.Time = (double)watchUpdate.ElapsedMilliseconds / 1000;
+            if (lastElapsedMilliseconds != 0)
+                updateEventArgs.Time = (double)(watchUpdate.ElapsedMilliseconds - lastElapsedMilliseconds) / 1000;
 
-            UpdateFrameInternal (updateEventArgs);
             watchUpdate.Restart();
+            UpdateFrameInternal (updateEventArgs);
+            lastElapsedMilliseconds = watchUpdate.ElapsedMilliseconds;
         }
 
         partial void log (string msg);

--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -521,12 +522,8 @@ namespace osuTK.Android
             get { return windowInfo.HasSurface && renderOn && !stopped; }
         }
 
-        private DateTime prevUpdateTime;
-        private DateTime prevRenderTime;
-        private DateTime curUpdateTime;
-        private DateTime curRenderTime;
+        private Stopwatch watchUpdate = new Stopwatch();
         private FrameEventArgs updateEventArgs = new FrameEventArgs();
-        private FrameEventArgs renderEventArgs = new FrameEventArgs();
 
         // this method is called on the main thread if RenderOnUIThread is true
         private void RunIteration (CancellationToken token)
@@ -537,14 +534,11 @@ namespace osuTK.Android
             if (!ReadyToRender)
                 return;
 
-            curUpdateTime = DateTime.Now;
-            if (prevUpdateTime.Ticks != 0) {
-                var t = (curUpdateTime - prevUpdateTime).TotalSeconds;
-                updateEventArgs.Time = t;
-            }
+            if (watchUpdate.ElapsedTicks != 0)
+                updateEventArgs.Time = (double)watchUpdate.ElapsedMilliseconds / 1000;
 
             UpdateFrameInternal (updateEventArgs);
-            prevUpdateTime = curUpdateTime;
+            watchUpdate.Restart();
         }
 
         partial void log (string msg);

--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -522,8 +522,7 @@ namespace osuTK.Android
             get { return windowInfo.HasSurface && renderOn && !stopped; }
         }
 
-        private Stopwatch watchUpdate = new Stopwatch();
-        private long lastElapsedMilliseconds;
+        private double lastTick;
 
         private FrameEventArgs updateEventArgs = new FrameEventArgs();
 
@@ -536,12 +535,11 @@ namespace osuTK.Android
             if (!ReadyToRender)
                 return;
 
-            if (lastElapsedMilliseconds != 0)
-                updateEventArgs.Time = (double)(watchUpdate.ElapsedMilliseconds - lastElapsedMilliseconds) / 1000;
+            if (lastTick != 0)
+                updateEventArgs.Time = (tick - lastTick) / 1000;
 
-            watchUpdate.Restart();
             UpdateFrameInternal (updateEventArgs);
-            lastElapsedMilliseconds = watchUpdate.ElapsedMilliseconds;
+            lastTick = tick;
         }
 
         partial void log (string msg);


### PR DESCRIPTION
Should (resolve) https://github.com/ppy/osu-framework/issues/2669.

The [`DateTime.Now` docs](https://docs.microsoft.com/en-us/dotnet/api/system.datetime.now?view=net-5.0) state the following:
> The resolution of this property depends on the system timer, which depends on the underlying operating system. It tends to be between 0.5 and 15 milliseconds. As a result, repeated calls to the Now property in a short time interval, such as in a loop, may return the same value.
>
> The Now property is frequently used to measure performance. However, because of its low resolution, it is not suitable for use as a benchmarking tool. A better alternative is to use the Stopwatch class.


Therefore on a game running over 60fps, there's a slight chance of hitting same time after a full frame iteration due to the low resolution it could have, and causing the above exception.

After speculating the above, I've went and repalced it with a `Stopwatch` instead, which should have a much higher resolution than `DateTime.Now`, and should hopefully resolve the mentioned issue. Quoting the [docs](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch?redirectedfrom=MSDN&view=net-5.0):

> The Stopwatch measures elapsed time by counting timer ticks in the underlying timer mechanism. If the installed hardware and operating system support a high-resolution performance counter, then the Stopwatch class uses that counter to measure elapsed time. Otherwise, the Stopwatch class uses the system timer to measure elapsed time. Use the Frequency and IsHighResolution fields to determine the precision and resolution of the Stopwatch timing implementation.

- [x] Pending testing (don't have the ability to test on android at the moment).