### PR TITLE
Fix previous iOS versions not handled with new display link logic

### DIFF
--- a/src/osuTK.iOS/iOSGameView.cs
+++ b/src/osuTK.iOS/iOSGameView.cs
@@ -150,7 +150,12 @@ namespace osuTK.iOS
             }
 
             displayLink = CADisplayLink.Create (this, selRunIteration);
-            displayLink.PreferredFrameRateRange = preferredFrameRateRange;
+
+            if (UIDevice.CurrentDevice.CheckSystemVersion(15, 0))
+                displayLink.PreferredFrameRateRange = preferredFrameRateRange;
+            else
+                displayLink.PreferredFramesPerSecond = (nint)preferredFrameRateRange.Preferred;
+
             displayLink.Paused = true;
         }
 


### PR DESCRIPTION
- Should resolve https://github.com/ppy/osu/discussions/16044

Can't test this yet as I'm waiting for the iOS 14 Simulator variant to finish downloading, which is gonna take a long period. So I'm PR'ing this in the mean time.