### PR TITLE
Preserve EGL context on app pause on Android

### DIFF
--- a/src/osuTK.Android/AndroidGameView.cs
+++ b/src/osuTK.Android/AndroidGameView.cs
@@ -25,9 +25,11 @@ using Android.Util;
 using Android.Views;
 using Android.Runtime;
 using Android.Graphics;
+using Android.Opengl;
 using osuTK.Platform.Egl;
 using SurfaceType = Android.Views.SurfaceType;
 using Size = System.Drawing.Size;
+using Javax.Microedition.Khronos.Opengles;
 
 namespace osuTK.Android
 {
@@ -81,6 +83,8 @@ namespace osuTK.Android
             ContextRenderingApi = GLVersion.ES1;
             mHolder = Holder;
             RenderThreadRestartRetries = 3;
+            PreserveEGLContextOnPause = true;
+            SetRenderer(new EmptyRenderer());
 
             // Add callback to get the SurfaceCreated etc events
             mHolder.AddCallback (this);
@@ -682,6 +686,27 @@ namespace osuTK.Android
                     size = value;
                     OnResize (EventArgs.Empty);
                 }
+            }
+        }
+
+        /// <summary>
+        /// On some devices, views inheriting <see cref="GLSurfaceView"/> need to call <see cref="GLSurfaceView.SetRenderer(IRenderer?)"/>,
+        /// even if the app manages GL calls on its own, in order to display any image on screen.
+        /// Therefore, this implementation is provided to make the view work without necessarily having to forward all GL calls
+        /// through the <see cref="GLSurfaceView.IRenderer"/> interface.
+        /// </summary>
+        private class EmptyRenderer : Java.Lang.Object, IRenderer
+        {
+            public void OnDrawFrame(IGL10 gl)
+            {
+            }
+
+            public void OnSurfaceChanged(IGL10 gl, int width, int height)
+            {
+            }
+
+            public void OnSurfaceCreated(IGL10 gl, Javax.Microedition.Khronos.Egl.EGLConfig config)
+            {
             }
         }
     }

--- a/src/osuTK.Android/GameViewBase.cs
+++ b/src/osuTK.Android/GameViewBase.cs
@@ -14,7 +14,7 @@ using osuTK.Platform;
 
 using Android.Content;
 using Android.Util;
-using Android.Views;
+using Android.Opengl;
 using Android.Runtime;
 
 using osuTK.Input;
@@ -25,7 +25,7 @@ using Android.App;
 namespace osuTK
 {
     [Register ("opentk_1_1/GameViewBase")]
-    public abstract class GameViewBase : SurfaceView, IGameWindow
+    public abstract class GameViewBase : GLSurfaceView, IGameWindow
     {
         private IGraphicsContext graphicsContext;
 


### PR DESCRIPTION
This is the minimum viable change that makes it so that osu!framework apps can run on Android without losing the GL context immediately upon pause. This is achieved using `GLSurfaceView` and its [`PreserveEGLContextOnPause`](https://developer.android.com/reference/android/opengl/GLSurfaceView#setPreserveEGLContextOnPause(boolean)) property (added in API level 11, so below the minimum version of 21 declared by framework projects and game).

Unfortunately I've had to also add and set a fake `IRenderer` instance, because without it the game would not render on one of my test devices. The renderer could be used in the future by framework to issue GL calls rather than fire them internally using `GLWrapper`, but I'm not going to be making that change now as that's a huge undertaking.

Tested on two Android devices that I own:

* Samsung Galaxy J7 2016 / SM-J710F (Android 7),
* OnePlus 8T / KB2003 (Android 11)

Change appears to have the desired effect on both.