### PR TITLE
Compile osuTK.Android for net6.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,11 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 build_script:
+  - cmd: dotnet workload restore
   - cmd: dotnet restore
   - cmd: dotnet run --project src/Generator.Bind/Generator.Bind.csproj -c:Release
   - cmd: dotnet pack src/osuTK/osuTK.NS20.csproj -c:Release /p:Version=%APPVEYOR_BUILD_VERSION%
   - cmd: msbuild /t:pack src/osuTK.iOS/osuTK.iOS.csproj /p:Configuration=Release /p:Version=%APPVEYOR_BUILD_VERSION%
-  - cmd: msbuild /t:pack src/osuTK.Android/osuTK.Android.csproj /p:Configuration=Release /p:Version=%APPVEYOR_BUILD_VERSION%
+  - cmd: dotnet pack src/osuTK.Android/osuTK.Android.csproj -c:Release /p:Version=%APPVEYOR_BUILD_VERSION%
 test: off
 version: 1.0.{build}
 artifacts:

--- a/src/osuTK.Android/osuTK.Android.csproj
+++ b/src/osuTK.Android/osuTK.Android.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -6,14 +6,9 @@
     <Title>ppy.osuTK.Android</Title>
     <RootNamespace>osuTK.Android</RootNamespace>
     <AssemblyName>osuTK.Android</AssemblyName>
-    <TargetFramework>monoandroid50</TargetFramework>
+    <TargetFramework>net6.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Core" />
-    <Reference Include="Mono.Android" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osuTK\osuTK.NS20.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Purpose of this PR

This PR is to workaround for https://github.com/mono/mono/issues/21239.

Certain types in `System.Drawing` namespace (The `Size`, `Rect` and `Point`s) lives in `System.Drawing.Primitives` on .NET Core, but on Xamarin they lived in `System.Drawing.Common`.
Installing the .NET Core version of `System.Drawing.Common` won't solve this issue, since there's no type forwarding in it, as these types were originally in `System.Drawing`.

A viable workaround at consumer side is to create an assembly with the name `System.Drawing.Common` and add `TypeForwardedTo` attributes for these types. This is unfriendly to nuget packaging. Since the main purpose of this fork is for osu-framework to consume, I think it's sure to change the target framework together with osu-framework.

### Testing status

- [x] Look if my CI change is correct.

### Comments

Such re-target will also be required for iOS once we do the moving. Should I include it in the same PR?
